### PR TITLE
fix: referenced WorkItems in rich text fields

### DIFF
--- a/src/main/java/ch/sbb/polarion/extension/diff_tool/service/MergeService.java
+++ b/src/main/java/ch/sbb/polarion/extension/diff_tool/service/MergeService.java
@@ -82,7 +82,7 @@ public class MergeService {
                         } else if (context.getSourceModule().getExternalWorkItems().contains(source)) {
                             prohibited.add(pair); // Don't allow merging referenced work item into included one
                         } else {
-                            merge(source, target, diffModel.getDiffFields());
+                            merge(source, target, diffModel.getDiffFields(), linkRole);
                             modified.add(pair);
                         }
                     }
@@ -286,9 +286,13 @@ public class MergeService {
         module.save();
     }
 
-    private void merge(IWorkItem source, IWorkItem target, List<DiffField> fields) {
+    private void merge(IWorkItem source, IWorkItem target, List<DiffField> fields, String linkRole) {
         for (DiffField field : fields) {
-            polarionService.setFieldValue(target, field.getKey(), polarionService.getFieldValue(source, field.getKey()));
+            Object fieldValue = polarionService.getFieldValue(source, field.getKey());
+            if (fieldValue instanceof Text text) {
+                fieldValue = new Text(text.getType(), polarionService.replaceLinksToPairedWorkItems(source, target, linkRole, text.getContent()));
+            }
+            polarionService.setFieldValue(target, field.getKey(), fieldValue);
         }
         target.save();
     }

--- a/ui/src/components/documents/DocumentsDiff.js
+++ b/ui/src/components/documents/DocumentsDiff.js
@@ -250,7 +250,7 @@ export default function DocumentsDiff() {
         </ul>
       </div>
       <div style={{display: notPaired.length > 0 ? 'block' : 'none'}}>
-        <p>Following work items referenced in source document do not have counterparts in target project and therefor were not referenced in target document:</p>
+        <p>Following work items referenced in source document do not have counterparts in target project and therefore were not referenced in target document:</p>
         <ul>
           {notPaired && notPaired.map((pair, index) => {
             return <li key={index}>{pair.leftWorkItem?.id}{pair.rightWorkItem?.id}</li>;


### PR DESCRIPTION
Refs: #87

### Proposed changes

Currently link to referenced WI inside rich text field can point to WI outside current project.
It necessary:
a) show that the fields are different if the links to WI are the same, but points to another project
b) by merge: replace the WI reference to counterpart WI form the same project

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
