### PR TITLE
fix: content at the last position isn't displayed in the diff

### DIFF
--- a/src/main/java/ch/sbb/polarion/extension/diff_tool/service/DocumentsContentHandler.java
+++ b/src/main/java/ch/sbb/polarion/extension/diff_tool/service/DocumentsContentHandler.java
@@ -53,6 +53,10 @@ class DocumentsContentHandler {
                 contentBuffer.append(element.outerHtml());
             }
         }
+        // put the rest content to the last anchor
+        if (!contentBuffer.isEmpty() && lastAnchor != null) {
+            lastAnchor.setContentBelow(contentBuffer.toString());
+        }
         return contentAnchors;
     }
 
@@ -95,7 +99,8 @@ class DocumentsContentHandler {
                 content.clear();
             }
         }
-        return Collections.emptyList();
+        // even if there were no more work items below the anchor, we have to return the rest content
+        return elementPassed && contentPosition == DocumentContentAnchor.ContentPosition.BELOW && !content.isEmpty() ? content : Collections.emptyList();
     }
 
     @VisibleForTesting

--- a/src/main/java/ch/sbb/polarion/extension/diff_tool/service/DocumentsContentHandler.java
+++ b/src/main/java/ch/sbb/polarion/extension/diff_tool/service/DocumentsContentHandler.java
@@ -77,6 +77,7 @@ class DocumentsContentHandler {
         }
     }
 
+    @SuppressWarnings("java:S3776") // ignore cognitive complexity complaint
     @VisibleForTesting
     List<Element> getContent(@NotNull Document sourceDocument, @NotNull String contentAnchorId, @NotNull DocumentContentAnchor.ContentPosition contentPosition) {
         List<Element> content = new ArrayList<>();

--- a/src/test/java/ch/sbb/polarion/extension/diff_tool/service/DocumentsContentHandlerTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/diff_tool/service/DocumentsContentHandlerTest.java
@@ -32,6 +32,7 @@ class DocumentsContentHandlerTest {
             <p>Paragraph above</p>
             <div id="polarion_wiki macro name=module-workitem;params=id=AA-3"></div>
             <div id="polarion_wiki macro name=module-workitem;params=id=AA-4"></div>
+            <p>Paragraph below the last</p>
         """);
         assertEquals(4, contentAnchors.size());
         assertTrue(contentAnchors.containsKey("AA-1"));
@@ -39,6 +40,7 @@ class DocumentsContentHandlerTest {
         assertTrue(contentAnchors.containsKey("AA-3"));
         assertTrue(contentAnchors.containsKey("AA-4"));
         assertEquals("<p>Paragraph above</p>", contentAnchors.get("AA-3").getContentAbove());
+        assertEquals("<p>Paragraph below the last</p>", contentAnchors.get("AA-4").getContentBelow());
     }
 
     @Test
@@ -99,6 +101,13 @@ class DocumentsContentHandlerTest {
     }
 
     @Test
+    void testGetContentBelowLastAnchor() {
+        Document document = generateTestDocument();
+        List<Element> elements = handler.getContent(document, "AA-4", DocumentContentAnchor.ContentPosition.BELOW);
+        assertEquals("<p>Paragraph below the last</p>", elements.get(0).toString());
+    }
+
+    @Test
     void testInsertContentAboveAnchor() {
         Document document = generateTestDocument();
 
@@ -107,7 +116,7 @@ class DocumentsContentHandlerTest {
         boolean contentModified = handler.insertContent(document, "AA-3", DocumentContentAnchor.ContentPosition.ABOVE, Collections.singletonList(element));
         assertTrue(contentModified);
 
-        assertEquals(5, document.body().children().size());
+        assertEquals(6, document.body().children().size());
 
         element = document.body().children().get(0);
         assertEquals("h2", element.tagName());
@@ -135,7 +144,7 @@ class DocumentsContentHandlerTest {
         boolean contentModified = handler.insertContent(document, "AA-3", DocumentContentAnchor.ContentPosition.BELOW, Collections.singletonList(element));
         assertTrue(contentModified);
 
-        assertEquals(6, document.body().children().size());
+        assertEquals(7, document.body().children().size());
 
         element = document.body().children().get(0);
         assertEquals("h2", element.tagName());
@@ -164,7 +173,7 @@ class DocumentsContentHandlerTest {
         boolean removed = handler.removeContent(document, document.body().children().get(0), document.body().children().get(3));
         assertTrue(removed);
 
-        assertEquals(3, document.body().children().size());
+        assertEquals(4, document.body().children().size());
 
         Element element = document.body().children().get(0);
         assertEquals("h2", element.tagName());
@@ -197,7 +206,7 @@ class DocumentsContentHandlerTest {
         boolean inserted = handler.insertContent(document, document.body().children().get(1), elementsToInsert);
         assertTrue(inserted);
 
-        assertEquals(7, document.body().children().size());
+        assertEquals(8, document.body().children().size());
 
         element = document.body().children().get(0);
         assertEquals("h2", element.tagName());
@@ -229,7 +238,7 @@ class DocumentsContentHandlerTest {
         boolean inserted = handler.insertContent(document, null, elementsToInsert);
         assertTrue(inserted);
 
-        assertEquals(7, document.body().children().size());
+        assertEquals(8, document.body().children().size());
 
         element = document.body().children().get(0);
         assertEquals("p", element.tagName());
@@ -303,6 +312,7 @@ class DocumentsContentHandlerTest {
             <p>Paragraph above</p>
             <div id="polarion_wiki macro name=module-workitem;params=id=AA-3"></div>
             <div id="polarion_wiki macro name=module-workitem;params=id=AA-4"></div>
+            <p>Paragraph below the last</p>
         """);
     }
 }

--- a/src/test/java/ch/sbb/polarion/extension/diff_tool/service/DocumentsContentHandlerTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/diff_tool/service/DocumentsContentHandlerTest.java
@@ -44,6 +44,11 @@ class DocumentsContentHandlerTest {
     }
 
     @Test
+    void testParseNoAnchors() {
+        assertTrue(handler.parse("").isEmpty());
+    }
+
+    @Test
     void testMergeDocuments() {
         IModule leftDocument = mock(IModule.class);
         when(leftDocument.getHomePageContent()).thenReturn(Text.html("""

--- a/src/test/java/ch/sbb/polarion/extension/diff_tool/service/DocumentsContentHandlerTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/diff_tool/service/DocumentsContentHandlerTest.java
@@ -111,6 +111,9 @@ class DocumentsContentHandlerTest {
 
         elements = handler.getContent(document, "BB-0", DocumentContentAnchor.ContentPosition.BELOW);
         assertTrue(elements.isEmpty());
+
+        elements = handler.getContent(Jsoup.parse(""), "AA-1", DocumentContentAnchor.ContentPosition.BELOW);
+        assertTrue(elements.isEmpty());
     }
 
     @Test

--- a/src/test/java/ch/sbb/polarion/extension/diff_tool/service/DocumentsContentHandlerTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/diff_tool/service/DocumentsContentHandlerTest.java
@@ -45,7 +45,7 @@ class DocumentsContentHandlerTest {
 
     @Test
     void testParseNoAnchors() {
-        assertTrue(handler.parse("").isEmpty());
+        assertTrue(handler.parse("<p>Some paragraph</p>").isEmpty());
     }
 
     @Test

--- a/src/test/java/ch/sbb/polarion/extension/diff_tool/service/DocumentsContentHandlerTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/diff_tool/service/DocumentsContentHandlerTest.java
@@ -101,10 +101,16 @@ class DocumentsContentHandlerTest {
     }
 
     @Test
-    void testGetContentBelowLastAnchor() {
+    void testGetContentAtTheEndOfDoc() {
         Document document = generateTestDocument();
         List<Element> elements = handler.getContent(document, "AA-4", DocumentContentAnchor.ContentPosition.BELOW);
         assertEquals("<p>Paragraph below the last</p>", elements.get(0).toString());
+
+        elements = handler.getContent(document, "AA-4", DocumentContentAnchor.ContentPosition.ABOVE);
+        assertTrue(elements.isEmpty());
+
+        elements = handler.getContent(document, "BB-0", DocumentContentAnchor.ContentPosition.BELOW);
+        assertTrue(elements.isEmpty());
     }
 
     @Test


### PR DESCRIPTION
Refs: #239

### Proposed changes

A text at the end of the document must be bound to the last work item in it.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
