### PR TITLE
feat: Add possibility to filter out linked WorkItems by role during diffing/merging

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -558,7 +558,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/HyperlinkRole"
+                  "$ref": "#/components/schemas/LinkRole"
                 }
               }
             },
@@ -566,6 +566,37 @@
           }
         },
         "summary": "Gets list of all hyperlink roles in the specified project",
+        "tags": [
+          "Utility API"
+        ]
+      }
+    },
+    "/api/projects/{projectId}/linked-workitem-roles": {
+      "get": {
+        "operationId": "getAllLinkedWorkItemRoles",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LinkRole"
+                }
+              }
+            },
+            "description": "List of all linked WorkItem roles for the specified project"
+          }
+        },
+        "summary": "Gets list of all linked WorkItem roles in the specified project",
         "tags": [
           "Utility API"
         ]
@@ -1831,26 +1862,6 @@
         },
         "type": "object"
       },
-      "HyperlinkRole": {
-        "properties": {
-          "combinedId": {
-            "type": "string"
-          },
-          "id": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "workItemTypeId": {
-            "type": "string"
-          },
-          "workItemTypeName": {
-            "type": "string"
-          }
-        },
-        "type": "object"
-      },
       "IStatusOpt": {
         "properties": {
           "default": {
@@ -1889,6 +1900,26 @@
       },
       "IType": {
         "description": "Type of the field",
+        "type": "object"
+      },
+      "LinkRole": {
+        "properties": {
+          "combinedId": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "workItemTypeId": {
+            "type": "string"
+          },
+          "workItemTypeName": {
+            "type": "string"
+          }
+        },
         "type": "object"
       },
       "MergeReport": {

--- a/src/main/java/ch/sbb/polarion/extension/diff_tool/rest/controller/UtilityApiController.java
+++ b/src/main/java/ch/sbb/polarion/extension/diff_tool/rest/controller/UtilityApiController.java
@@ -7,7 +7,7 @@ import ch.sbb.polarion.extension.diff_tool.rest.model.diff.Document;
 import ch.sbb.polarion.extension.diff_tool.rest.model.diff.DocumentRevision;
 import ch.sbb.polarion.extension.diff_tool.rest.model.diff.Space;
 import ch.sbb.polarion.extension.diff_tool.rest.model.diff.WorkItemField;
-import ch.sbb.polarion.extension.diff_tool.rest.model.settings.HyperlinkRole;
+import ch.sbb.polarion.extension.diff_tool.rest.model.settings.LinkRole;
 import ch.sbb.polarion.extension.generic.rest.filter.Secured;
 import ch.sbb.polarion.extension.generic.util.ExtensionInfo;
 import com.polarion.alm.tracker.model.IStatusOpt;
@@ -40,8 +40,13 @@ public class UtilityApiController extends UtilityInternalController {
     }
 
     @Override
-    public Collection<HyperlinkRole> getAllHyperlinkRoles(String projectId) {
+    public Collection<LinkRole> getAllHyperlinkRoles(String projectId) {
         return polarionService.callPrivileged(() -> super.getAllHyperlinkRoles(projectId));
+    }
+
+    @Override
+    public Collection<LinkRole> getAllLinkedWorkItemRoles(String projectId) {
+        return polarionService.callPrivileged(() -> super.getAllLinkedWorkItemRoles(projectId));
     }
 
     @Override

--- a/src/main/java/ch/sbb/polarion/extension/diff_tool/rest/controller/UtilityInternalController.java
+++ b/src/main/java/ch/sbb/polarion/extension/diff_tool/rest/controller/UtilityInternalController.java
@@ -8,11 +8,10 @@ import ch.sbb.polarion.extension.diff_tool.rest.model.diff.Document;
 import ch.sbb.polarion.extension.diff_tool.rest.model.diff.DocumentRevision;
 import ch.sbb.polarion.extension.diff_tool.rest.model.diff.Space;
 import ch.sbb.polarion.extension.diff_tool.rest.model.diff.WorkItemField;
-import ch.sbb.polarion.extension.diff_tool.rest.model.settings.HyperlinkRole;
+import ch.sbb.polarion.extension.diff_tool.rest.model.settings.LinkRole;
 import ch.sbb.polarion.extension.diff_tool.service.PolarionService;
 import ch.sbb.polarion.extension.generic.util.ExtensionInfo;
 import com.polarion.alm.projects.model.IProject;
-import com.polarion.alm.tracker.model.IHyperlinkRoleOpt;
 import com.polarion.alm.tracker.model.IStatusOpt;
 import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
@@ -193,16 +192,38 @@ public class UtilityInternalController {
                             description = "List of all hyperlink roles for the specified project",
                             content = @Content(
                                     mediaType = MediaType.APPLICATION_JSON,
-                                    schema = @Schema(implementation = HyperlinkRole.class)
+                                    schema = @Schema(implementation = LinkRole.class)
                             )
                     )
             }
     )
-    public Collection<HyperlinkRole> getAllHyperlinkRoles(@PathParam("projectId") String projectId) {
+    public Collection<LinkRole> getAllHyperlinkRoles(@PathParam("projectId") String projectId) {
         if (StringUtils.isBlank(projectId)) {
             throw new BadRequestException(MISSING_PROJECT_ID_MESSAGE);
         }
         return polarionService.getHyperlinkRoles(projectId);
+    }
+
+    @GET
+    @Path("/projects/{projectId}/linked-workitem-roles")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(summary = "Gets list of all linked WorkItem roles in the specified project",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "List of all linked WorkItem roles for the specified project",
+                            content = @Content(
+                                    mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = LinkRole.class)
+                            )
+                    )
+            }
+    )
+    public Collection<LinkRole> getAllLinkedWorkItemRoles(@PathParam("projectId") String projectId) {
+        if (StringUtils.isBlank(projectId)) {
+            throw new BadRequestException(MISSING_PROJECT_ID_MESSAGE);
+        }
+        return polarionService.getLinkedWorkItemRoles(projectId);
     }
 
     @GET

--- a/src/main/java/ch/sbb/polarion/extension/diff_tool/rest/model/settings/DiffModel.java
+++ b/src/main/java/ch/sbb/polarion/extension/diff_tool/rest/model/settings/DiffModel.java
@@ -27,6 +27,7 @@ public class DiffModel extends SettingsModel {
     private static final String DIFF_FIELDS = "DIFF FIELDS";
     private static final String STATUSES_TO_IGNORE = "STATUSES TO IGNORE";
     private static final String HYPERLINK_ROLES = "HYPERLINK ROLES";
+    private static final String LINKED_WORKITEM_ROLES = "LINKED WORKITEM ROLES";
 
     @Builder.Default
     private List<DiffField> diffFields = new ArrayList<>();
@@ -34,12 +35,15 @@ public class DiffModel extends SettingsModel {
     private List<String> statusesToIgnore = new ArrayList<>();
     @Builder.Default
     private List<String> hyperlinkRoles = new ArrayList<>();
+    @Builder.Default
+    private List<String> linkedWorkItemRoles = new ArrayList<>();
 
     @Override
     protected String serializeModelData() {
         return serializeEntry(DIFF_FIELDS, diffFields)
                 + serializeEntry(STATUSES_TO_IGNORE, statusesToIgnore)
-                + serializeEntry(HYPERLINK_ROLES, hyperlinkRoles);
+                + serializeEntry(HYPERLINK_ROLES, hyperlinkRoles)
+                + serializeEntry(LINKED_WORKITEM_ROLES, linkedWorkItemRoles);
     }
 
     @Override
@@ -69,6 +73,16 @@ public class DiffModel extends SettingsModel {
             try {
                 String[] rolesArray = new ObjectMapper().readValue(hyperlinkRolesString, String[].class);
                 hyperlinkRoles = new ArrayList<>(Arrays.asList(rolesArray));
+            } catch (JsonProcessingException e) {
+                throw new IllegalArgumentException("Hyperlink roles value couldn't be parsed", e);
+            }
+        }
+
+        String linkedWorkItemRolesString = deserializeEntry(LINKED_WORKITEM_ROLES, serializedString);
+        if (linkedWorkItemRolesString != null) {
+            try {
+                String[] rolesArray = new ObjectMapper().readValue(linkedWorkItemRolesString, String[].class);
+                linkedWorkItemRoles = new ArrayList<>(Arrays.asList(rolesArray));
             } catch (JsonProcessingException e) {
                 throw new IllegalArgumentException("Hyperlink roles value couldn't be parsed", e);
             }

--- a/src/main/java/ch/sbb/polarion/extension/diff_tool/rest/model/settings/DiffModel.java
+++ b/src/main/java/ch/sbb/polarion/extension/diff_tool/rest/model/settings/DiffModel.java
@@ -84,7 +84,7 @@ public class DiffModel extends SettingsModel {
                 String[] rolesArray = new ObjectMapper().readValue(linkedWorkItemRolesString, String[].class);
                 linkedWorkItemRoles = new ArrayList<>(Arrays.asList(rolesArray));
             } catch (JsonProcessingException e) {
-                throw new IllegalArgumentException("Hyperlink roles value couldn't be parsed", e);
+                throw new IllegalArgumentException("Linked WorkItem roles value couldn't be parsed", e);
             }
         }
     }

--- a/src/main/java/ch/sbb/polarion/extension/diff_tool/rest/model/settings/LinkRole.java
+++ b/src/main/java/ch/sbb/polarion/extension/diff_tool/rest/model/settings/LinkRole.java
@@ -13,7 +13,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class HyperlinkRole {
+public class LinkRole {
 
     @EqualsAndHashCode.Include
     private String id;

--- a/src/main/java/ch/sbb/polarion/extension/diff_tool/service/MergeService.java
+++ b/src/main/java/ch/sbb/polarion/extension/diff_tool/service/MergeService.java
@@ -725,6 +725,12 @@ public class MergeService {
 
         Collection<ILinkedWorkItemStruct> srcLinks = getLinks(source, false);
         Collection<ILinkedWorkItemStruct> targetLinks = getLinks(target, false);
+        if (!context.getDiffModel().getLinkedWorkItemRoles().isEmpty()) {
+            srcLinks = srcLinks.stream()
+                    .filter(link -> context.getDiffModel().getLinkedWorkItemRoles().contains(link.getLinkRole().getId())).toList();
+            targetLinks = targetLinks.stream()
+                    .filter(link -> context.getDiffModel().getLinkedWorkItemRoles().contains(link.getLinkRole().getId())).toList();
+        }
 
         List<ILinkedWorkItemStruct> sameLinks = new ArrayList<>();
         List<String> interlinkedSrcIds = new ArrayList<>();

--- a/src/main/java/ch/sbb/polarion/extension/diff_tool/service/PolarionService.java
+++ b/src/main/java/ch/sbb/polarion/extension/diff_tool/service/PolarionService.java
@@ -8,7 +8,7 @@ import ch.sbb.polarion.extension.diff_tool.rest.model.diff.DocumentRevision;
 import ch.sbb.polarion.extension.diff_tool.rest.model.diff.WorkItemField;
 import ch.sbb.polarion.extension.diff_tool.rest.model.diff.WorkItemsPair;
 import ch.sbb.polarion.extension.diff_tool.rest.model.settings.AuthorizationModel;
-import ch.sbb.polarion.extension.diff_tool.rest.model.settings.HyperlinkRole;
+import ch.sbb.polarion.extension.diff_tool.rest.model.settings.LinkRole;
 import ch.sbb.polarion.extension.diff_tool.service.cleaners.FieldCleaner;
 import ch.sbb.polarion.extension.diff_tool.service.cleaners.ListFieldCleaner;
 import ch.sbb.polarion.extension.diff_tool.service.cleaners.NonListFieldCleaner;
@@ -423,15 +423,23 @@ public class PolarionService extends ch.sbb.polarion.extension.generic.service.P
     }
 
     @NotNull
-    public Collection<HyperlinkRole> getHyperlinkRoles(@NotNull String projectId) {
-        Set<HyperlinkRole> hyperlinks = new LinkedHashSet<>();
+    public Collection<LinkRole> getHyperlinkRoles(@NotNull String projectId) {
+        Set<LinkRole> roles = new LinkedHashSet<>();
         ITrackerProject trackerProject = getTrackerProject(projectId);
         for (ITypeOpt wiType : trackerProject.getWorkItemTypeEnum().getAllOptions()) {
-            hyperlinks.addAll(trackerProject.getHyperlinkRoleEnum()
+            roles.addAll(trackerProject.getHyperlinkRoleEnum()
                     .getAvailableOptions(wiType.getId()).stream()
-                    .map(e -> new HyperlinkRole(e.getId(), e.getName(), wiType.getId(), wiType.getName())).toList());
+                    .map(e -> new LinkRole(e.getId(), e.getName(), wiType.getId(), wiType.getName())).toList());
         }
-        return hyperlinks;
+        return roles;
+    }
+
+    @NotNull
+    public Collection<LinkRole> getLinkedWorkItemRoles(@NotNull String projectId) {
+        ITrackerProject trackerProject = getTrackerProject(projectId);
+        return trackerProject.getWorkItemLinkRoleEnum()
+                .getAllOptions().stream()
+                .map(e -> LinkRole.builder().id(e.getId()).name(e.getName()).build()).toList();
     }
 
     @SneakyThrows

--- a/src/main/java/ch/sbb/polarion/extension/diff_tool/service/handler/impl/HyperlinksHandler.java
+++ b/src/main/java/ch/sbb/polarion/extension/diff_tool/service/handler/impl/HyperlinksHandler.java
@@ -1,7 +1,7 @@
 package ch.sbb.polarion.extension.diff_tool.service.handler.impl;
 
 import ch.sbb.polarion.extension.diff_tool.rest.model.diff.WorkItem;
-import ch.sbb.polarion.extension.diff_tool.rest.model.settings.HyperlinkRole;
+import ch.sbb.polarion.extension.diff_tool.rest.model.settings.LinkRole;
 import ch.sbb.polarion.extension.diff_tool.service.handler.DiffContext;
 import ch.sbb.polarion.extension.diff_tool.service.handler.DiffLifecycleHandler;
 import ch.sbb.polarion.extension.diff_tool.util.ModificationType;
@@ -51,7 +51,7 @@ public class HyperlinksHandler implements DiffLifecycleHandler {
         List<String> resultRows = new ArrayList<>();
         List<String> rolesToMerge = Optional.of(context.diffModel.getHyperlinkRoles())
                 .filter(settingsRoles -> !settingsRoles.isEmpty())
-                .orElseGet(() -> context.polarionService.getHyperlinkRoles(context.leftProjectId).stream().map(HyperlinkRole::getCombinedId).toList())
+                .orElseGet(() -> context.polarionService.getHyperlinkRoles(context.leftProjectId).stream().map(LinkRole::getCombinedId).toList())
                 .stream().filter(combinedId -> combinedId.startsWith(wiTypeId + "#"))
                 .map(combinedId -> combinedId.substring(combinedId.indexOf("#") + 1)).toList();
 

--- a/src/main/java/ch/sbb/polarion/extension/diff_tool/service/handler/impl/LinkedWorkItemsHandler.java
+++ b/src/main/java/ch/sbb/polarion/extension/diff_tool/service/handler/impl/LinkedWorkItemsHandler.java
@@ -18,6 +18,7 @@ import com.polarion.platform.persistence.IEnumOption;
 import lombok.NoArgsConstructor;
 import org.apache.commons.lang3.tuple.Pair;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.VisibleForTesting;
 
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -131,7 +132,8 @@ public class LinkedWorkItemsHandler implements DiffLifecycleHandler {
         return String.join("", resultRows);
     }
 
-    private String renderLinkedItem(ILinkedWorkItemStruct link, IWorkItem parentWorkItem, boolean backLink) {
+    @VisibleForTesting
+    String renderLinkedItem(ILinkedWorkItemStruct link, IWorkItem parentWorkItem, boolean backLink) {
         return TransactionalExecutor.executeSafelyInReadOnlyTransaction(trx -> {
             HtmlFragmentBuilder fragmentBuilder = RichTextRenderTarget.EDITOR.selectBuilderTarget(trx.context().createHtmlFragmentBuilderFor());
             InternalReadOnlyTransaction internalReadOnlyTransaction = (InternalReadOnlyTransaction) trx;
@@ -141,11 +143,13 @@ public class LinkedWorkItemsHandler implements DiffLifecycleHandler {
         });
     }
 
-    private String markChanged(String text, @NotNull ModificationType modificationType) {
+    @VisibleForTesting
+    String markChanged(String text, @NotNull ModificationType modificationType) {
         return "<div class=\"diff-lwi-container\"><div class=\"%s diff-lwi\">%s</div></div>".formatted(modificationType.getStyleName(), text);
     }
 
-    private boolean isInappropriateCaseForHandler(DiffContext context) {
+    @VisibleForTesting
+    boolean isInappropriateCaseForHandler(DiffContext context) {
         return context.pairedWorkItemsDiffer || !Stream.of(context.fieldA.getId(), context.fieldB.getId()).filter(Objects::nonNull).distinct().toList().equals(List.of(KEY_LINKED_WORK_ITEMS));
     }
 }

--- a/src/main/java/ch/sbb/polarion/extension/diff_tool/service/handler/impl/LinkedWorkItemsHandler.java
+++ b/src/main/java/ch/sbb/polarion/extension/diff_tool/service/handler/impl/LinkedWorkItemsHandler.java
@@ -66,7 +66,7 @@ public class LinkedWorkItemsHandler implements DiffLifecycleHandler {
                     if (role.getName() == null) {
                         logger.warn("Link role '%s' with null name encountered: looks like the link role has been removed from configuration".formatted(role.getId()));
                     }
-                    return true;
+                    return context.diffModel.getLinkedWorkItemRoles().isEmpty() || context.diffModel.getLinkedWorkItemRoles().contains(role.getId());
                 })
                 .distinct()
                 .sorted(Comparator.comparing(IEnumOption::getName, Comparator.nullsLast(String::compareTo)))

--- a/src/main/java/ch/sbb/polarion/extension/diff_tool/settings/DiffSettings.java
+++ b/src/main/java/ch/sbb/polarion/extension/diff_tool/settings/DiffSettings.java
@@ -7,7 +7,6 @@ import ch.sbb.polarion.extension.diff_tool.rest.model.settings.DiffModel;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 public class DiffSettings extends GenericNamedSettings<DiffModel> {

--- a/src/main/java/ch/sbb/polarion/extension/diff_tool/settings/DiffSettings.java
+++ b/src/main/java/ch/sbb/polarion/extension/diff_tool/settings/DiffSettings.java
@@ -31,7 +31,6 @@ public class DiffSettings extends GenericNamedSettings<DiffModel> {
 
         return DiffModel.builder()
                 .diffFields(defaultFields)
-                .statusesToIgnore(Collections.emptyList())
                 .build();
     }
 }

--- a/src/main/resources/webapp/diff-tool-admin/pages/configuration.jsp
+++ b/src/main/resources/webapp/diff-tool-admin/pages/configuration.jsp
@@ -41,6 +41,7 @@
         }
         .select-column {
             width: 440px;
+            min-height: 200px;
         }
         .select-column select {
             height: 100%;
@@ -80,6 +81,9 @@
         <div id="hyperlink-roles-load-error" class="diff-fields-error" style="display: none; margin-bottom: 15px">
             There was an error loading list of available hyperlink roles.
         </div>
+        <div id="linked-workitem-roles-load-error" class="diff-fields-error" style="display: none; margin-bottom: 15px">
+            There was an error loading list of available roles of linked WorkItems.
+        </div>
 
         <div class="flex-container">
             <div class="column select-column">
@@ -113,6 +117,13 @@
                 <label for="hyperlink-roles">Hyperlink roles to diff and merge</label>
                 <input type="text" id="search-hyperlink-roles-input" placeholder="Filter items">
                 <select id="hyperlink-roles" multiple size="10" style="height: 200px">
+                </select>
+            </div>
+
+            <div id="linked-workitem-settings-container" class="column select-column">
+                <label for="hyperlink-roles">Roles of linked WorkItems to diff and merge</label>
+                <input type="text" id="search-linked-workitem-roles-input" placeholder="Filter items">
+                <select id="linked-workitem-roles" multiple size="10" style="height: 200px">
                 </select>
             </div>
         </div>

--- a/src/test/java/ch/sbb/polarion/extension/diff_tool/rest/model/settings/DiffModelTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/diff_tool/rest/model/settings/DiffModelTest.java
@@ -11,8 +11,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -99,6 +97,40 @@ class DiffModelTest {
         assertEquals(expectedStatusesToIgnore, model.getStatusesToIgnore());
         assertEquals(expectedHyperlinkRoles, model.getHyperlinkRoles());
         assertEquals(expectedLinkedWorkItemRoles, model.getLinkedWorkItemRoles());
+    }
+
+    private static Stream<Arguments> testInvalidValuesForDiffModel() {
+        return Stream.of(
+                Arguments.of(String.format(
+                                "-----BEGIN DIFF FIELDS-----%1$s" +
+                                "[{\"wrong_key\":\"any_value\"}]%1$s" +
+                                "-----END DIFF FIELDS-----%1$s",
+                        System.lineSeparator()), "Diff fields value couldn't be parsed"),
+                Arguments.of(String.format(
+                                "-----BEGIN STATUSES TO IGNORE-----%1$s" +
+                                "{\"wrong_key\":\"any_value\"}%1$s" +
+                                "-----END STATUSES TO IGNORE-----%1$s",
+                        System.lineSeparator()), "Statuses to ignore value couldn't be parsed"),
+                Arguments.of(String.format(
+                                "-----BEGIN HYPERLINK ROLES-----%1$s" +
+                                "{}%1$s" +
+                                "-----END HYPERLINK ROLES-----%1$s",
+                        System.lineSeparator()), "Hyperlink roles value couldn't be parsed"),
+                Arguments.of(String.format(
+                                "-----BEGIN LINKED WORKITEM ROLES-----%1$s" +
+                                "%1$s" +
+                                "-----END LINKED WORKITEM ROLES-----%1$s",
+                        System.lineSeparator()), "Linked WorkItem roles value couldn't be parsed")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("testInvalidValuesForDiffModel")
+    void getProperInvalidResults(String modelContent, String expectedMessage) {
+        DiffModel model = new DiffModel();
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> model.deserialize(modelContent));
+        assertEquals(expectedMessage, exception.getMessage());
     }
 
     @Test

--- a/src/test/java/ch/sbb/polarion/extension/diff_tool/rest/model/settings/DiffModelTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/diff_tool/rest/model/settings/DiffModelTest.java
@@ -25,9 +25,9 @@ class DiffModelTest {
 
     private static Stream<Arguments> testValuesForDiffModel() {
         return Stream.of(
-                Arguments.of(null, null, Collections.emptyList(), Collections.emptyList(), Collections.emptyList()),
-                Arguments.of("", null, Collections.emptyList(), Collections.emptyList(), Collections.emptyList()),
-                Arguments.of("some badly formatted string", null, Collections.emptyList(), Collections.emptyList(), Collections.emptyList()),
+                Arguments.of(null, null, List.of(), List.of(), List.of(), List.of()),
+                Arguments.of("", null, List.of(), List.of(), List.of(), List.of()),
+                Arguments.of("some badly formatted string", null, List.of(), List.of(), List.of(), List.of()),
                 Arguments.of(String.format("ok file" +
                                 "-----BEGIN BUNDLE TIMESTAMP-----%1$s" +
                                 "12345%1$s" +
@@ -40,16 +40,22 @@ class DiffModelTest {
                                 "-----END STATUSES TO IGNORE-----%1$s" +
                                 "-----BEGIN HYPERLINK ROLES-----%1$s" +
                                 "[\"ref_int\"]%1$s" +
-                                "-----END HYPERLINK ROLES-----%1$s",
-                        System.lineSeparator()), "12345", Arrays.asList(DiffField.builder().key("status").build(), DiffField.builder().key("title").build()), Collections.singletonList("inprogress"), Collections.singletonList("ref_int")),
+                                "-----END HYPERLINK ROLES-----%1$s" +
+                                "-----BEGIN LINKED WORKITEM ROLES-----%1$s" +
+                                "[\"relates_to\"]%1$s" +
+                                "-----END LINKED WORKITEM ROLES-----%1$s",
+                        System.lineSeparator()), "12345", List.of(DiffField.builder().key("status").build(), DiffField.builder().key("title").build()), List.of("inprogress"), List.of("ref_int"), List.of("relates_to")),
                 Arguments.of(String.format("no bundle timestamp" +
                                 "-----BEGIN DIFF FIELDS-----%1$s" +
                                 "[{\"key\":\"title\",\"wiTypeId\":\"assumption\"}]" +
                                 "-----END DIFF FIELDS-----%1$s" +
                                 "-----BEGIN STATUSES TO IGNORE-----%1$s" +
                                 "[\"draft\",\"open\"]%1$s" +
-                                "-----END STATUSES TO IGNORE-----%1$s",
-                        System.lineSeparator()), null, Collections.singletonList(DiffField.builder().key("title").wiTypeId("assumption").build()), Arrays.asList("draft", "open"), List.of()),
+                                "-----END STATUSES TO IGNORE-----%1$s" +
+                                "-----BEGIN LINKED WORKITEM ROLES-----%1$s" +
+                                "[\"parent\",\"relates_to\"]%1$s" +
+                                "-----END LINKED WORKITEM ROLES-----%1$s",
+                        System.lineSeparator()), null, List.of(DiffField.builder().key("title").wiTypeId("assumption").build()), List.of("draft", "open"), List.of(), List.of("parent", "relates_to")),
                 Arguments.of(String.format("keep first duplicated entry" +
                                 "-----BEGIN BUNDLE TIMESTAMP-----%1$s" +
                                 "ts1%1$s" +
@@ -75,14 +81,15 @@ class DiffModelTest {
                                 "-----BEGIN HYPERLINK ROLES-----%1$s" +
                                 "[\"ref_int\"]%1$s" +
                                 "-----END HYPERLINK ROLES-----%1$s",
-                        System.lineSeparator()), "ts1", Arrays.asList(DiffField.builder().key("status").build(), DiffField.builder().key("title").build()), Arrays.asList("draft", "open"), List.of())
+                        System.lineSeparator()), "ts1", List.of(DiffField.builder().key("status").build(), DiffField.builder().key("title").build()), List.of("draft", "open"), List.of(), List.of())
         );
     }
 
     @ParameterizedTest
     @MethodSource("testValuesForDiffModel")
     void getProperExpectedResults(String locationContent, String expectedBundleTimestamp,
-                                  List<DiffField> expectedFields, List<String> expectedStatusesToIgnore, List<String> expectedHyperlinkRoles) {
+                                  List<DiffField> expectedFields, List<String> expectedStatusesToIgnore,
+                                  List<String> expectedHyperlinkRoles, List<String> expectedLinkedWorkItemRoles) {
 
         DiffModel model = new DiffModel();
         model.deserialize(locationContent);
@@ -91,6 +98,7 @@ class DiffModelTest {
         assertEquals(expectedFields, model.getDiffFields());
         assertEquals(expectedStatusesToIgnore, model.getStatusesToIgnore());
         assertEquals(expectedHyperlinkRoles, model.getHyperlinkRoles());
+        assertEquals(expectedLinkedWorkItemRoles, model.getLinkedWorkItemRoles());
     }
 
     @Test

--- a/src/test/java/ch/sbb/polarion/extension/diff_tool/rest/model/settings/LinkRoleTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/diff_tool/rest/model/settings/LinkRoleTest.java
@@ -1,0 +1,13 @@
+package ch.sbb.polarion.extension.diff_tool.rest.model.settings;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class LinkRoleTest {
+
+    @Test
+    void testGetCombinedId() {
+        assertEquals("type#role", new LinkRole("role", "name", "type", "typeName").getCombinedId());
+    }
+}

--- a/src/test/java/ch/sbb/polarion/extension/diff_tool/service/MergeServiceTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/diff_tool/service/MergeServiceTest.java
@@ -1248,7 +1248,7 @@ class MergeServiceTest {
 
         SettingsAwareMergeContext context = mock(SettingsAwareMergeContext.class);
         lenient().when(context.getLinkRole()).thenReturn("role1");
-        lenient().when(context.getDiffModel()).thenReturn(new DiffModel());
+        lenient().when(context.getDiffModel()).thenReturn(DiffModel.builder().linkedWorkItemRoles(List.of("role1")).build());
 
         mergeService.mergeLinkedWorkItems(source, target, context, new WorkItemsPair());
 

--- a/src/test/java/ch/sbb/polarion/extension/diff_tool/service/MergeServiceTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/diff_tool/service/MergeServiceTest.java
@@ -14,7 +14,7 @@ import ch.sbb.polarion.extension.diff_tool.rest.model.diff.WorkItem;
 import ch.sbb.polarion.extension.diff_tool.rest.model.diff.WorkItemsMergeParams;
 import ch.sbb.polarion.extension.diff_tool.rest.model.diff.WorkItemsPair;
 import ch.sbb.polarion.extension.diff_tool.rest.model.settings.DiffModel;
-import ch.sbb.polarion.extension.diff_tool.rest.model.settings.HyperlinkRole;
+import ch.sbb.polarion.extension.diff_tool.rest.model.settings.LinkRole;
 import ch.sbb.polarion.extension.diff_tool.settings.DiffSettings;
 import ch.sbb.polarion.extension.diff_tool.util.DiffModelCachedResource;
 import ch.sbb.polarion.extension.generic.context.CurrentContextConfig;
@@ -1426,10 +1426,10 @@ class MergeServiceTest {
         when(workItem.getType()).thenReturn(typeOpt);
 
         when(workItem.getProjectId()).thenReturn("projectId");
-        HyperlinkRole hyperlinkRole = mock(HyperlinkRole.class);
-        when(hyperlinkRole.getId()).thenReturn("role");
-        when(hyperlinkRole.getWorkItemTypeId()).thenReturn("type");
-        when(polarionService.getHyperlinkRoles("projectId")).thenReturn(List.of(hyperlinkRole));
+        LinkRole linkRole = mock(LinkRole.class);
+        when(linkRole.getId()).thenReturn("role");
+        when(linkRole.getWorkItemTypeId()).thenReturn("type");
+        when(polarionService.getHyperlinkRoles("projectId")).thenReturn(List.of(linkRole));
 
         when(diffModel.getHyperlinkRoles()).thenReturn(List.of("", "type#role", "type#wrongHyperlinkRole"));
         when(context.getDiffModel()).thenReturn(diffModel);
@@ -1475,10 +1475,10 @@ class MergeServiceTest {
         List<HyperlinkStruct> newLinksList = List.of(newLink);
 
         when(workItem.getProjectId()).thenReturn("projectId");
-        HyperlinkRole hyperlinkRole = mock(HyperlinkRole.class);
-        when(hyperlinkRole.getId()).thenReturn("role");
-        when(hyperlinkRole.getWorkItemTypeId()).thenReturn("type");
-        when(polarionService.getHyperlinkRoles("projectId")).thenReturn(List.of(hyperlinkRole));
+        LinkRole linkRole = mock(LinkRole.class);
+        when(linkRole.getId()).thenReturn("role");
+        when(linkRole.getWorkItemTypeId()).thenReturn("type");
+        when(polarionService.getHyperlinkRoles("projectId")).thenReturn(List.of(linkRole));
 
         mergeService.mergeHyperlinks(workItem, newLinksList, context, pair);
 

--- a/src/test/java/ch/sbb/polarion/extension/diff_tool/service/MergeServiceTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/diff_tool/service/MergeServiceTest.java
@@ -1206,7 +1206,7 @@ class MergeServiceTest {
                 Arguments.of(anotherProject(null), linksList(a1rev1role1), linksList(b1rev1role1), List.of(), List.of()),
 
                 // src has the same but another revision link - target link removed and added a new one
-                Arguments.of(sameProject(), linksList(a1rev2role1), linksList(a1rev1role1), List.of(),
+                Arguments.of(sameProject(), linksList(a1rev2role1, a1rev1role2), linksList(a1rev1role1), List.of(),
                         List.of(new AddLinkedItemInvocation("projA", "A-1", "2", "role1"))),
 
                 // interlinked items - link stays at its place
@@ -1248,6 +1248,7 @@ class MergeServiceTest {
 
         SettingsAwareMergeContext context = mock(SettingsAwareMergeContext.class);
         lenient().when(context.getLinkRole()).thenReturn("role1");
+        lenient().when(context.getDiffModel()).thenReturn(new DiffModel());
 
         mergeService.mergeLinkedWorkItems(source, target, context, new WorkItemsPair());
 

--- a/src/test/java/ch/sbb/polarion/extension/diff_tool/service/handler/impl/LinkedWorkItemsHandlerTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/diff_tool/service/handler/impl/LinkedWorkItemsHandlerTest.java
@@ -1,0 +1,167 @@
+package ch.sbb.polarion.extension.diff_tool.service.handler.impl;
+
+import ch.sbb.polarion.extension.diff_tool.rest.model.diff.WorkItem;
+import ch.sbb.polarion.extension.diff_tool.rest.model.diff.WorkItemsPairDiffParams;
+import ch.sbb.polarion.extension.diff_tool.rest.model.settings.DiffModel;
+import ch.sbb.polarion.extension.diff_tool.service.PolarionService;
+import ch.sbb.polarion.extension.diff_tool.service.handler.DiffContext;
+import ch.sbb.polarion.extension.diff_tool.settings.DiffSettings;
+import ch.sbb.polarion.extension.generic.settings.NamedSettingsRegistry;
+import ch.sbb.polarion.extension.generic.settings.SettingName;
+import com.polarion.alm.tracker.model.ILinkRoleOpt;
+import com.polarion.alm.tracker.model.ILinkedWorkItemStruct;
+import com.polarion.alm.tracker.model.IModule;
+import com.polarion.alm.tracker.model.IStatusOpt;
+import com.polarion.alm.tracker.model.ITrackerProject;
+import com.polarion.alm.tracker.model.IWorkItem;
+import com.polarion.subterra.base.location.ILocation;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Answers;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.lenient;
+
+class LinkedWorkItemsHandlerTest {
+    private static final String PROJECT_ID = "projectId";
+    private static final String LINK_ROLE_ID_1 = "roleId1";
+    private static final String LINK_ROLE_ID_2 = "roleId2";
+    private static final String LINK_ROLE_ID_3 = "roleId3";
+
+    @AfterEach
+    void tearDown() {
+        // Unregister our mock settings
+        NamedSettingsRegistry.INSTANCE.getAll().clear();
+    }
+
+    @Test
+    void testPreProcessAppropriateCase() {
+        WorkItem.Field fieldA = WorkItem.Field.builder().id("linkedWorkItems").build();
+        WorkItem.Field fieldB = WorkItem.Field.builder().build();
+        DiffContext context = new DiffContext(fieldA, fieldB, PROJECT_ID, mock(PolarionService.class));
+
+        assertEquals(Pair.of("", ""), new LinkedWorkItemsHandler().preProcess(Pair.of("valueA", "valueB"), context));
+    }
+
+    @Test
+    void testPreProcessInappropriateCase() {
+        WorkItem.Field fieldA = WorkItem.Field.builder().build();
+        WorkItem.Field fieldB = WorkItem.Field.builder().id("test").build();
+        DiffContext context = new DiffContext(fieldA, fieldB, PROJECT_ID, mock(PolarionService.class));
+
+        assertEquals(Pair.of("valueA", "valueB"), new LinkedWorkItemsHandler().preProcess(Pair.of("valueA", "valueB"), context));
+    }
+
+    @Test
+    void testPostProcessAppropriateCase() {
+        ITrackerProject trackerProject = mock(ITrackerProject.class);
+
+        DiffSettings settings = mock(DiffSettings.class, Answers.RETURNS_DEEP_STUBS);
+
+        when(settings.getFeatureName()).thenReturn(DiffSettings.FEATURE_NAME);
+        when(settings.readNames(any())).thenReturn(Set.of(SettingName.builder().id("settingId").name("settingName").build()));
+        when(settings.read(any(), any(), any())).thenReturn(DiffModel.builder().linkedWorkItemRoles(List.of(LINK_ROLE_ID_1)).build());
+        NamedSettingsRegistry.INSTANCE.register(List.of(settings));
+
+        IModule document1 = mockDocument("document1", new Date());
+        IWorkItem underlyingObjectA = mockWorkItem(trackerProject, document1, "A", "done");
+        IWorkItem linkA1 = mockWorkItem(trackerProject, document1, "A1", "open");
+        IWorkItem linkA2 = mockWorkItem(trackerProject, document1, "A2", "in_progress");
+        IWorkItem linkA3 = mockWorkItem(trackerProject, document1, "A3", "closed");
+        mockLinks(underlyingObjectA, List.of(mockLink(linkA1, LINK_ROLE_ID_1), mockLink(linkA2, LINK_ROLE_ID_2)), List.of(mockLink(linkA3, LINK_ROLE_ID_3)));
+
+        WorkItem workItemA = WorkItem.builder().underlyingObject(underlyingObjectA).build();
+        WorkItem.Field fieldA = WorkItem.Field.builder().id("linkedWorkItems").build();
+        workItemA.addField(fieldA);
+
+        IModule document2 = mockDocument("document2", new Date());
+        IWorkItem underlyingObjectB = mockWorkItem(trackerProject, document2, "B", "done");
+        IWorkItem linkB1 = mockWorkItem(trackerProject, document2, "B1", "open");
+        IWorkItem linkB2 = mockWorkItem(trackerProject, document2, "B2", "in_progress");
+        IWorkItem linkB3 = mockWorkItem(trackerProject, document2, "B3", "closed");
+        mockLinks(underlyingObjectB, List.of(mockLink(linkB1, LINK_ROLE_ID_1)), List.of(mockLink(linkB2, LINK_ROLE_ID_2), mockLink(linkB3, LINK_ROLE_ID_3)));
+
+        WorkItem workItemB = WorkItem.builder().underlyingObject(underlyingObjectB).build();
+        WorkItem.Field fieldB = WorkItem.Field.builder().id("linkedWorkItems").build();
+        workItemB.addField(fieldB);
+
+        DiffContext context = new DiffContext(workItemA, workItemB, "linkedWorkItems",
+                WorkItemsPairDiffParams.builder().leftProjectId(PROJECT_ID).configName("Default").build(), mock(PolarionService.class));
+
+        LinkedWorkItemsHandler linkedWorkItemsHandlerPartiallyMocked = mock(LinkedWorkItemsHandler.class);
+        when(linkedWorkItemsHandlerPartiallyMocked.postProcess(any(), any())).thenCallRealMethod();
+        when(linkedWorkItemsHandlerPartiallyMocked.isInappropriateCaseForHandler(any())).thenCallRealMethod();
+        when(linkedWorkItemsHandlerPartiallyMocked.markChanged(anyString(), any())).thenCallRealMethod();
+        when(linkedWorkItemsHandlerPartiallyMocked.renderLinkedItem(any(), any(), anyBoolean())).thenAnswer(invocation -> {
+            ILinkedWorkItemStruct link = invocation.getArgument(0);
+            boolean isBackLink = invocation.getArgument(2);
+            IWorkItem linkedItem = link.getLinkedItem();
+            return String.format("<span>%s</span>: <span><span>%s</span> - <span>%s</span></span>", isBackLink ? link.getLinkRole().getOppositeName() : link.getLinkRole().getName(),
+                    linkedItem.getId(), linkedItem.getTitle());
+        });
+
+        assertEquals("""
+                    <div class="diff-lwi-container"><div class="diff-html-added diff-lwi"><span>roleId1_name</span>: <span><span>ID-B1</span> - <span>Title B1</span></span></div></div><div class="diff-lwi-container"><div class="diff-html-removed diff-lwi"><span>roleId1_name</span>: <span><span>ID-B1</span> - <span>Title B1</span></span></div></div>""",
+                linkedWorkItemsHandlerPartiallyMocked.postProcess("not_relevant", context));
+    }
+
+    @Test
+    void testPostProcessInappropriateCase() {
+        WorkItem.Field fieldA = WorkItem.Field.builder().build();
+        WorkItem.Field fieldB = WorkItem.Field.builder().id("test").build();
+        DiffContext context = new DiffContext(fieldA, fieldB, PROJECT_ID, mock(PolarionService.class));
+
+        assertEquals("to_be_untouched", new LinkedWorkItemsHandler().postProcess("to_be_untouched", context));
+    }
+
+    private IModule mockDocument(String name, Date created) {
+        IModule document = mock(IModule.class);
+        lenient().when(document.getProjectId()).thenReturn(PROJECT_ID);
+        lenient().when(document.getModuleNameWithSpace()).thenReturn(name);
+        ILocation location = mock(ILocation.class);
+        when(location.removeRevision()).thenReturn(location);
+        when(document.getModuleLocation()).thenReturn(location);
+        lenient().when(document.getCreated()).thenReturn(created);
+        return document;
+    }
+
+    private IWorkItem mockWorkItem(ITrackerProject trackerProject, IModule module, String index, String status) {
+        IStatusOpt statusOpt = mock(IStatusOpt.class);
+        lenient().when(statusOpt.getId()).thenReturn(status);
+
+        IWorkItem workItem = mock(IWorkItem.class);
+        lenient().when(workItem.getId()).thenReturn("ID-" + index);
+        lenient().when(workItem.getTitle()).thenReturn("Title " + index);
+        lenient().when(workItem.getModule()).thenReturn(module);
+        lenient().when(workItem.getProjectId()).thenReturn(PROJECT_ID);
+
+        lenient().when(workItem.getStatus()).thenReturn(statusOpt);
+        lenient().when(trackerProject.getWorkItem("ID-" + index)).thenReturn(workItem);
+        return workItem;
+    }
+
+    private void mockLinks(IWorkItem workItem, List<ILinkedWorkItemStruct> direct, List<ILinkedWorkItemStruct> back) {
+        lenient().when(workItem.getLinkedWorkItemsStructsDirect()).thenReturn(direct);
+        lenient().when(workItem.getLinkedWorkItemsStructsBack()).thenReturn(back);
+    }
+
+    private ILinkedWorkItemStruct mockLink(IWorkItem linkedItem, String linkedRoleId) {
+        ILinkedWorkItemStruct link = mock(ILinkedWorkItemStruct.class);
+        lenient().when(link.getLinkedItem()).thenReturn(linkedItem);
+
+        ILinkRoleOpt role = mock(ILinkRoleOpt.class);
+        lenient().when(role.getId()).thenReturn(linkedRoleId);
+        lenient().when(role.getName()).thenReturn(linkedRoleId + "_name");
+        lenient().when(role.getOppositeName()).thenReturn(linkedRoleId + "_opposite_name");
+        lenient().when(link.getLinkRole()).thenReturn(role);
+        return link;
+    }
+
+}


### PR DESCRIPTION
Add possibility to filter out linked WorkItems by role during diffing/merging

Fixes #277

### Proposed changes

During diffing and merging only those linked WorkItems will be taken into account, which roles were selected in diffing configuration, or all if no roles were selected in configuration.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
