### PR TITLE
fix: clean up fields which were copied into created target work item from source work item which were not configured for merge (if possible)

### DIFF
--- a/src/main/java/ch/sbb/polarion/extension/diff_tool/service/PolarionService.java
+++ b/src/main/java/ch/sbb/polarion/extension/diff_tool/service/PolarionService.java
@@ -103,7 +103,7 @@ import java.util.stream.Stream;
 public class PolarionService extends ch.sbb.polarion.extension.generic.service.PolarionService {
 
     private static final Logger logger = Logger.getLogger(PolarionService.class);
-    private static final Predicate<WorkItemField> deletableFieldsFilter = field -> !field.isReadOnly();
+    static final Predicate<WorkItemField> deletableFieldsFilter = field -> !field.isReadOnly();
     private static final Set<String> fieldsNotToCleanUp = new HashSet<>(Arrays.asList(
             IUniqueObject.KEY_PROJECT,
             IWorkItem.KEY_MODULE,

--- a/src/test/java/ch/sbb/polarion/extension/diff_tool/service/MergeServiceTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/diff_tool/service/MergeServiceTest.java
@@ -968,7 +968,6 @@ class MergeServiceTest {
                 WorkItemField.builder().key("status").build(),
                 WorkItemField.builder().key("priority").build()
         ));
-
         WorkItemsPair pair = mock(WorkItemsPair.class);
         IWorkItem iWorkItem = mock(IWorkItem.class, RETURNS_DEEP_STUBS);
 

--- a/src/test/java/ch/sbb/polarion/extension/diff_tool/service/MergeServiceTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/diff_tool/service/MergeServiceTest.java
@@ -11,6 +11,7 @@ import ch.sbb.polarion.extension.diff_tool.rest.model.diff.MergeDirection;
 import ch.sbb.polarion.extension.diff_tool.rest.model.diff.MergeResult;
 import ch.sbb.polarion.extension.diff_tool.rest.model.diff.Project;
 import ch.sbb.polarion.extension.diff_tool.rest.model.diff.WorkItem;
+import ch.sbb.polarion.extension.diff_tool.rest.model.diff.WorkItemField;
 import ch.sbb.polarion.extension.diff_tool.rest.model.diff.WorkItemsMergeParams;
 import ch.sbb.polarion.extension.diff_tool.rest.model.diff.WorkItemsPair;
 import ch.sbb.polarion.extension.diff_tool.rest.model.settings.DiffModel;
@@ -86,6 +87,11 @@ class MergeServiceTest {
 
     @BeforeEach
     void init() {
+        when(polarionService.getStandardFields()).thenReturn(List.of(
+                WorkItemField.builder().key("title").build(),
+                WorkItemField.builder().key("status").build(),
+                WorkItemField.builder().key("priority").build()
+        ));
         mergeService = new MergeService(polarionService);
     }
 
@@ -973,6 +979,10 @@ class MergeServiceTest {
         when(context.getTargetWorkItem(pair)).thenReturn(target);
 
         DiffModel diffModel = mock(DiffModel.class);
+        when(diffModel.getDiffFields()).thenReturn(List.of(
+                DiffField.builder().key("title").build(),
+                DiffField.builder().key("status").build()
+        ));
         when(context.getDiffModel()).thenReturn(diffModel);
 
         when(source.getId()).thenReturn("sourceId");

--- a/src/test/java/ch/sbb/polarion/extension/diff_tool/service/MergeServiceTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/diff_tool/service/MergeServiceTest.java
@@ -87,11 +87,6 @@ class MergeServiceTest {
 
     @BeforeEach
     void init() {
-        when(polarionService.getStandardFields()).thenReturn(List.of(
-                WorkItemField.builder().key("title").build(),
-                WorkItemField.builder().key("status").build(),
-                WorkItemField.builder().key("priority").build()
-        ));
         mergeService = new MergeService(polarionService);
     }
 
@@ -968,6 +963,12 @@ class MergeServiceTest {
 
     @Test
     void testCopyWorkItemWhenTargetIsNull() {
+        when(polarionService.getStandardFields()).thenReturn(List.of(
+                WorkItemField.builder().key("title").build(),
+                WorkItemField.builder().key("status").build(),
+                WorkItemField.builder().key("priority").build()
+        ));
+
         WorkItemsPair pair = mock(WorkItemsPair.class);
         IWorkItem iWorkItem = mock(IWorkItem.class, RETURNS_DEEP_STUBS);
 

--- a/src/test/java/ch/sbb/polarion/extension/diff_tool/service/MergeServiceTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/diff_tool/service/MergeServiceTest.java
@@ -44,6 +44,7 @@ import com.polarion.alm.tracker.model.ITypeOpt;
 import com.polarion.alm.tracker.model.IWorkItem;
 import com.polarion.core.util.types.Text;
 import com.polarion.platform.persistence.model.IPObjectList;
+import com.polarion.subterra.base.data.identification.IContextId;
 import com.polarion.subterra.base.data.model.IEnumType;
 import com.polarion.subterra.base.data.model.IListType;
 import com.polarion.subterra.base.data.model.IStructType;
@@ -979,6 +980,9 @@ class MergeServiceTest {
         IModule sourceModule = mock(IModule.class);
         IModule targetModule = mock(IModule.class);
         when(targetModule.getProjectId()).thenReturn("projectA");
+        ITrackerProject targetProjectMock = mock(ITrackerProject.class);
+        when(targetProjectMock.getContextId()).thenReturn(mock(IContextId.class));
+        when(targetModule.getProject()).thenReturn(targetProjectMock);
         when(context.getTargetModule()).thenReturn(targetModule);
 
         when(polarionService.getPairedWorkItems(iWorkItem, "projectA", null)).thenReturn(List.of());

--- a/src/test/java/ch/sbb/polarion/extension/diff_tool/service/MergeServiceTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/diff_tool/service/MergeServiceTest.java
@@ -968,6 +968,8 @@ class MergeServiceTest {
                 WorkItemField.builder().key("status").build(),
                 WorkItemField.builder().key("priority").build()
         ));
+        when(polarionService.getDeletableFields(any(), any(), any())).thenCallRealMethod();
+
         WorkItemsPair pair = mock(WorkItemsPair.class);
         IWorkItem iWorkItem = mock(IWorkItem.class, RETURNS_DEEP_STUBS);
 


### PR DESCRIPTION
Fixes #293

### Proposed changes

Clean up fields which were copied into created target work item from source work item which were not configured for merge (if possible)

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
