### PR TITLE
fix: attachments aren't copied during the merge despite the option is…

### DIFF
--- a/src/main/java/ch/sbb/polarion/extension/diff_tool/rest/model/diff/DocumentsMergeParams.java
+++ b/src/main/java/ch/sbb/polarion/extension/diff_tool/rest/model/diff/DocumentsMergeParams.java
@@ -32,6 +32,7 @@ public class DocumentsMergeParams extends MergeParams {
     @Schema(description = "Indicates if missing referenced document attachments must be copied")
     private boolean copyMissingDocumentAttachments;
 
+    @SuppressWarnings("java:S107")
     public DocumentsMergeParams(DocumentIdentifier leftDocument, DocumentIdentifier rightDocument, MergeDirection direction, String linkRole,
                                 String configName, String configCacheBucketId, List<WorkItemsPair> pairs, Boolean allowReferencedWorkItemMerge) {
         super(direction, linkRole, configName, configCacheBucketId, pairs);

--- a/src/main/java/ch/sbb/polarion/extension/diff_tool/service/MergeService.java
+++ b/src/main/java/ch/sbb/polarion/extension/diff_tool/service/MergeService.java
@@ -79,6 +79,7 @@ import static ch.sbb.polarion.extension.diff_tool.report.MergeReport.OperationRe
 import static ch.sbb.polarion.extension.diff_tool.util.DiffToolUtils.*;
 import static com.polarion.alm.tracker.model.IWithAttachments.KEY_ATTACHMENTS;
 
+@SuppressWarnings({"java:S1192", "java:S3776", "java:S135", "java:S1066"})
 public class MergeService {
 
     private static final String TEST_STEPS = "steps";

--- a/src/test/java/ch/sbb/polarion/extension/diff_tool/service/MergeServiceTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/diff_tool/service/MergeServiceTest.java
@@ -88,7 +88,7 @@ import static org.mockito.Mockito.*;
 
 @ExtendWith({MockitoExtension.class, CurrentContextExtension.class})
 @CurrentContextConfig("diff-tool")
-@SuppressWarnings({"unchecked", "rawtypes"})
+@SuppressWarnings({"unchecked", "rawtypes", "java:S1117"})
 class MergeServiceTest {
     @Mock
     private PolarionService polarionService;


### PR DESCRIPTION
… selected on the side panel

Refs: #370

### Proposed changes

Flag must be properly set to enable attachments copy.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
