### PR TITLE
fix: prevent diff-tool and copy-tool panes be initialized each time document is saved

### DIFF
--- a/src/main/resources/webapp/diff-tool/js/modules/CopyTool.js
+++ b/src/main/resources/webapp/diff-tool/js/modules/CopyTool.js
@@ -9,6 +9,12 @@ export default class CopyTool extends GenericMixin {
 
     this.ctx = new ExtensionContext({});
 
+    const copyToolPane = this.ctx.querySelector(".copy.form-wrapper");
+    if (!copyToolPane || copyToolPane.classList.contains("initialized")) {
+      return; // Skip if copy-tool pane wasn't found or was already initialized
+    }
+    copyToolPane.classList.add("initialized");
+
     this.sourceProjectId = sourceProjectId;
     this.settingsProjectId = sourceProjectId;
     this.sourceSpace = sourceSpace;

--- a/src/main/resources/webapp/diff-tool/js/modules/DiffTool.js
+++ b/src/main/resources/webapp/diff-tool/js/modules/DiffTool.js
@@ -9,6 +9,12 @@ export default class DiffTool extends GenericMixin {
 
     this.ctx = new ExtensionContext({});
 
+    const diffToolPane = this.ctx.querySelector(".comparison.form-wrapper");
+    if (!diffToolPane || diffToolPane.classList.contains("initialized")) {
+      return; // Skip if diff-tool pane wasn't found or was already initialized
+    }
+    diffToolPane.classList.add("initialized");
+
     this.sourceProjectId = sourceProjectId;
     this.settingsProjectId = sourceProjectId;
     this.sourceSpace = sourceSpace;


### PR DESCRIPTION

### Proposed changes

Each time document is saved (without reloading the Polarion) diff-tool and copy-tool panes are initialized, as a consequence JS modules are loaded multiple time, listeners are added multiple times and so on. This fix is preventing this.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
