### PR TITLE
fix: enable Create Document button only when all dropdowns are selected

### DIFF
--- a/src/main/resources/webapp/diff-tool/js/modules/CopyTool.js
+++ b/src/main/resources/webapp/diff-tool/js/modules/CopyTool.js
@@ -45,12 +45,14 @@ export default class CopyTool extends GenericMixin {
       element: '#copy-link-role-selector',
       placeholder: 'Select Link Role...'
     });
+    this.ctx.onChange('copy-link-role-selector', () => this.updateCreateButtonState());
     this.linkRoleDropdown.restoreSelection();
 
     this.configDropdown = new SearchableDropdown({
       element: '#copy-config-selector',
       placeholder: 'Select Configuration...'
     });
+    this.ctx.onChange('copy-config-selector', () => this.updateCreateButtonState());
     this.configDropdown.restoreSelection();
 
     this.handleRefsDropdown = new SearchableDropdown({
@@ -58,6 +60,7 @@ export default class CopyTool extends GenericMixin {
       placeholder: 'Select Behaviour...',
       searchable: false
     });
+    this.ctx.onChange('handle-refs-selector', () => this.updateCreateButtonState());
     this.handleRefsDropdown.restoreSelection();
 
   }
@@ -71,8 +74,16 @@ export default class CopyTool extends GenericMixin {
   }
 
   spaceChanged() {
+    this.updateCreateButtonState();
+  }
+
+  updateCreateButtonState() {
+    const selectedProject = this.ctx.getValue("copy-project-selector");
     const selectedSpace = this.ctx.getValue("copy-space-selector");
-    this.ctx.disableIf("create-document", !selectedSpace);
+    const linkRole = this.ctx.getValue("copy-link-role-selector");
+    const config = this.ctx.getValue("copy-config-selector");
+    const handleRefs = this.ctx.getValue("handle-refs-selector");
+    this.ctx.disableIf("create-document", !selectedProject || !selectedSpace || !linkRole || !config || !handleRefs);
   }
 
   createNewDocument() {


### PR DESCRIPTION
Refs: #402

### Proposed changes

 The "Create Document" button should only be enabled when all required dropdowns have values selected.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
