### PR TITLE
feat: Copy livedoc comments when duplicating documents

### DIFF
--- a/src/test/java/ch/sbb/polarion/extension/diff_tool/util/OutlineNumberComparatorTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/diff_tool/util/OutlineNumberComparatorTest.java
@@ -1,13 +1,19 @@
 package ch.sbb.polarion.extension.diff_tool.util;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class OutlineNumberComparatorTest {
+
+    private final OutlineNumberComparator comparator = new OutlineNumberComparator();
 
     @Test
     void testOutlineNumbersOrder() {
@@ -33,7 +39,7 @@ class OutlineNumberComparatorTest {
                 "1.24.16-3"
         ));
 
-        inputList.sort(new OutlineNumberComparator());
+        inputList.sort(comparator);
 
         assertThat(inputList).isEqualTo(Arrays.asList(
                 "1.1",
@@ -56,5 +62,54 @@ class OutlineNumberComparatorTest {
                 "3",
                 "25"
         ));
+    }
+
+    @Test
+    void testEqualOutlineNumbers() {
+        assertEquals(0, comparator.compare("1.2.3", "1.2.3"));
+        assertEquals(0, comparator.compare("1", "1"));
+        assertEquals(0, comparator.compare("1.2-3", "1.2-3"));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "1, 2",
+            "1.1, 1.2",
+            "1.1.1, 1.1.2",
+            "1.1, 1.1.1",
+            "1.1-1, 1.1-2",
+            "1.1, 1.1-1",
+    })
+    void testLessThanComparisons(String smaller, String larger) {
+        assertTrue(comparator.compare(smaller, larger) < 0, smaller + " should be less than " + larger);
+        assertTrue(comparator.compare(larger, smaller) > 0, larger + " should be greater than " + smaller);
+    }
+
+    @Test
+    void testSingleSegmentNumbers() {
+        ArrayList<String> numbers = new ArrayList<>(Arrays.asList("10", "2", "1", "20", "3"));
+        numbers.sort(comparator);
+        assertThat(numbers).containsExactly("1", "2", "3", "10", "20");
+    }
+
+    @Test
+    void testWithoutSuffix_prefixIsParentOfLonger() {
+        assertTrue(comparator.compare("1.2", "1.2.3") < 0);
+        assertTrue(comparator.compare("1.2.3", "1.2") > 0);
+    }
+
+    @Test
+    void testNonNumericSegment_treatedAsZero() {
+        // Non-numeric parts are parsed as 0 via parseLongSafely
+        assertEquals(0, comparator.compare("abc", "0"));
+    }
+
+    @Test
+    void testCachingDoesNotAffectResults() {
+        // Use same comparator instance multiple times to exercise cache
+        assertTrue(comparator.compare("1.1", "1.2") < 0);
+        assertTrue(comparator.compare("1.2", "1.3") < 0);
+        assertTrue(comparator.compare("1.1", "1.3") < 0);
+        assertEquals(0, comparator.compare("1.2", "1.2"));
     }
 }


### PR DESCRIPTION
### Proposed changes

Polarion doesn't copy LiveDoc comments when duplicating documents. We add our own logic to fill this gap.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
