### PR TITLE
feat: add possibility to choose if document comments should be copied or not

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1455,6 +1455,7 @@
             "type": "string"
           },
           "copyDocumentComments": {
+            "default": false,
             "description": "Whether document comments should be copied to the target document",
             "type": "boolean"
           },

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1454,6 +1454,10 @@
             "description": "The configuration name to use for the duplication, which specifies which fields of work items to copy",
             "type": "string"
           },
+          "copyDocumentComments": {
+            "description": "Whether document comments should be copied to the target document",
+            "type": "boolean"
+          },
           "handleReferences": {
             "default": "DEFAULT",
             "description": "Declares how references should be handled during copy operation",

--- a/src/main/java/ch/sbb/polarion/extension/diff_tool/rest/model/DocumentDuplicateParams.java
+++ b/src/main/java/ch/sbb/polarion/extension/diff_tool/rest/model/DocumentDuplicateParams.java
@@ -28,6 +28,9 @@ public class DocumentDuplicateParams {
     @Schema(description = "Declares how references should be handled during copy operation", defaultValue = "DEFAULT")
     private HandleReferencesType handleReferences;
 
+    @Schema(description = "Whether document comments should be copied to the target document")
+    private boolean copyDocumentComments;
+
     public String getConfigName() {
         return configName != null ? configName : NamedSettings.DEFAULT_NAME;
     }

--- a/src/main/java/ch/sbb/polarion/extension/diff_tool/rest/model/DocumentDuplicateParams.java
+++ b/src/main/java/ch/sbb/polarion/extension/diff_tool/rest/model/DocumentDuplicateParams.java
@@ -28,7 +28,7 @@ public class DocumentDuplicateParams {
     @Schema(description = "Declares how references should be handled during copy operation", defaultValue = "DEFAULT")
     private HandleReferencesType handleReferences;
 
-    @Schema(description = "Whether document comments should be copied to the target document")
+    @Schema(description = "Whether document comments should be copied to the target document", defaultValue = "false")
     private boolean copyDocumentComments;
 
     public String getConfigName() {

--- a/src/main/java/ch/sbb/polarion/extension/diff_tool/service/DocumentCopyService.java
+++ b/src/main/java/ch/sbb/polarion/extension/diff_tool/service/DocumentCopyService.java
@@ -113,10 +113,12 @@ public class DocumentCopyService {
             return createdModule;
         }));
 
-        TransactionalExecutor.executeInWriteTransaction(transaction -> {
-            copyModuleComments(sourceModule, targetModule);
-            return null;
-        });
+        if (documentDuplicateParams.isCopyDocumentComments()) {
+            TransactionalExecutor.executeInWriteTransaction(transaction -> {
+                copyModuleComments(sourceModule, targetModule);
+                return null;
+            });
+        }
 
         TransactionalExecutor.executeInWriteTransaction(transaction -> {
             if (linkRole != null && !sourceProjectId.equals(documentDuplicateParams.getTargetDocumentIdentifier().getProjectId())) {

--- a/src/main/resources/webapp/diff-tool/html/copy-tool.html
+++ b/src/main/resources/webapp/diff-tool/html/copy-tool.html
@@ -44,6 +44,11 @@
         </select>
     </div>
 
+    <div class='property-wrapper'>
+        <input type='checkbox' id='copy-comments-checkbox'/>
+        <label for='copy-comments-checkbox'>Copy document comments</label>
+    </div>
+
     <div class='buttons-wrapper'>
         <button type='button' id="create-document" disabled>
             <img src='/polarion/ria/images/control/tablePlus.png' alt=""/>Create Document

--- a/src/main/resources/webapp/diff-tool/js/modules/CopyTool.js
+++ b/src/main/resources/webapp/diff-tool/js/modules/CopyTool.js
@@ -105,6 +105,7 @@ export default class CopyTool extends GenericMixin {
       linkRoleId: linkRole,
       configName: config,
       handleReferences: handleRefs,
+      copyDocumentComments: this.ctx.getElementById("copy-comments-checkbox").checked,
     };
     const revisionUrlPart = this.sourceRevision ? `?revision=${this.sourceRevision}` : '';
 

--- a/src/test/java/ch/sbb/polarion/extension/diff_tool/rest/model/DocumentDuplicateParamsTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/diff_tool/rest/model/DocumentDuplicateParamsTest.java
@@ -4,6 +4,7 @@ import ch.sbb.polarion.extension.generic.settings.NamedSettings;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -20,6 +21,7 @@ class DocumentDuplicateParamsTest {
                 .linkRoleId("linkRole1")
                 .configName("customConfig")
                 .handleReferences(HandleReferencesType.KEEP)
+                .copyDocumentComments(true)
                 .build();
 
         assertEquals(targetDoc, params.getTargetDocumentIdentifier());
@@ -27,6 +29,7 @@ class DocumentDuplicateParamsTest {
         assertEquals("linkRole1", params.getLinkRoleId());
         assertEquals("customConfig", params.getConfigName());
         assertEquals(HandleReferencesType.KEEP, params.getHandleReferences());
+        assertTrue(params.isCopyDocumentComments());
     }
 
     @Test
@@ -37,6 +40,7 @@ class DocumentDuplicateParamsTest {
         assertNull(params.getTargetDocumentTitle());
         assertNull(params.getLinkRoleId());
         assertNull(params.getHandleReferences());
+        assertFalse(params.isCopyDocumentComments());
     }
 
     @Test
@@ -44,13 +48,14 @@ class DocumentDuplicateParamsTest {
         BaseDocumentIdentifier targetDoc = new BaseDocumentIdentifier("project", "space", "doc");
 
         DocumentDuplicateParams params = new DocumentDuplicateParams(
-                targetDoc, "Title", "role", "config", HandleReferencesType.CREATE_MISSING);
+                targetDoc, "Title", "role", "config", HandleReferencesType.CREATE_MISSING, true);
 
         assertEquals(targetDoc, params.getTargetDocumentIdentifier());
         assertEquals("Title", params.getTargetDocumentTitle());
         assertEquals("role", params.getLinkRoleId());
         assertEquals("config", params.getConfigName());
         assertEquals(HandleReferencesType.CREATE_MISSING, params.getHandleReferences());
+        assertTrue(params.isCopyDocumentComments());
     }
 
     @Test
@@ -79,12 +84,14 @@ class DocumentDuplicateParamsTest {
         params.setLinkRoleId("newRole");
         params.setConfigName("newConfig");
         params.setHandleReferences(HandleReferencesType.ALWAYS_OVERWRITE);
+        params.setCopyDocumentComments(true);
 
         assertEquals(targetDoc, params.getTargetDocumentIdentifier());
         assertEquals("New Title", params.getTargetDocumentTitle());
         assertEquals("newRole", params.getLinkRoleId());
         assertEquals("newConfig", params.getConfigName());
         assertEquals(HandleReferencesType.ALWAYS_OVERWRITE, params.getHandleReferences());
+        assertTrue(params.isCopyDocumentComments());
     }
 
     @Test
@@ -97,6 +104,7 @@ class DocumentDuplicateParamsTest {
                 .linkRoleId("role")
                 .configName("config")
                 .handleReferences(HandleReferencesType.DEFAULT)
+                .copyDocumentComments(true)
                 .build();
 
         DocumentDuplicateParams params2 = DocumentDuplicateParams.builder()
@@ -105,6 +113,7 @@ class DocumentDuplicateParamsTest {
                 .linkRoleId("role")
                 .configName("config")
                 .handleReferences(HandleReferencesType.DEFAULT)
+                .copyDocumentComments(true)
                 .build();
 
         assertEquals(params1, params2);

--- a/src/test/java/ch/sbb/polarion/extension/diff_tool/service/DocumentCopyServiceTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/diff_tool/service/DocumentCopyServiceTest.java
@@ -122,7 +122,7 @@ class DocumentCopyServiceTest {
         when(projectService.getProject("srcProj")).thenReturn(sourceProject);
         when(projectService.getProject("targetProjectId")).thenReturn(targetProject);
 
-        DocumentDuplicateParams duplicateParams = new DocumentDuplicateParams(targetDocumentIdentifier, "targetTitle", "linkRoleId", "configName", HandleReferencesType.DEFAULT);
+        DocumentDuplicateParams duplicateParams = new DocumentDuplicateParams(targetDocumentIdentifier, "targetTitle", "linkRoleId", "configName", HandleReferencesType.DEFAULT, false);
 
         IModule sourceModule = mock(IModule.class, RETURNS_DEEP_STUBS);
         when(trackerService.getModuleManager().getModule(eq(sourceProject), any())).thenReturn(sourceModule);
@@ -164,6 +164,8 @@ class DocumentCopyServiceTest {
                 copyService.createDocumentDuplicate("srcProj", "srcSpace", "srcDocName", "123", duplicateParams));
         verify(copyService, times(0)).fixLinksInRichTextFields(any(), any(), nullable(String.class), any());
         verify(trackerService.getFolderManager(), times(1)).createFolder(nullable(String.class), nullable(String.class), nullable(String.class));
+        // copyDocumentComments is false, so comments should not be copied
+        verify(copyService, never()).copyModuleComments(any(), any());
 
         // provide link role + make it available
         duplicateParams.setLinkRoleId("linkRoleId");
@@ -174,6 +176,14 @@ class DocumentCopyServiceTest {
         assertDoesNotThrow(() ->
                 copyService.createDocumentDuplicate("srcProj", "srcSpace", "srcDocName", "123", duplicateParams));
         verify(copyService, times(1)).fixLinksInRichTextFields(any(), any(), nullable(String.class), any());
+        // still no comment copying since copyDocumentComments is false
+        verify(copyService, never()).copyModuleComments(any(), any());
+
+        // now enable copying comments
+        duplicateParams.setCopyDocumentComments(true);
+        assertDoesNotThrow(() ->
+                copyService.createDocumentDuplicate("srcProj", "srcSpace", "srcDocName", "123", duplicateParams));
+        verify(copyService, times(1)).copyModuleComments(any(), any());
     }
 
     @Test


### PR DESCRIPTION
Fixes #441

### Proposed changes

After implementing #420 document comments were copied always unconditionally. This change adds a checkbox for user to choose if to copy them or not.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
