### PR TITLE
fix: comparison logic should allow missing link role for same documents

### DIFF
--- a/src/main/java/ch/sbb/polarion/extension/diff_tool/rest/controller/DiffInternalController.java
+++ b/src/main/java/ch/sbb/polarion/extension/diff_tool/rest/controller/DiffInternalController.java
@@ -78,7 +78,11 @@ public class DiffInternalController {
             }
     )
     public DocumentsDiff getDocumentsDiff(@Parameter(required = true) DocumentsDiffParams documentsDiffParams) {
-        if (documentsDiffParams == null || documentsDiffParams.getLeftDocument() == null || documentsDiffParams.getRightDocument() == null || documentsDiffParams.getLinkRole() == null) {
+        if (documentsDiffParams == null
+                || documentsDiffParams.getLeftDocument() == null
+                || documentsDiffParams.getRightDocument() == null
+                || (documentsDiffParams.getLinkRole() == null
+                && !documentsDiffParams.getLeftDocument().pointsToSameDocumentAs(documentsDiffParams.getRightDocument()))) {
             throw new BadRequestException("Parameters 'leftDocument', 'rightDocument' and 'linkRole' should be provided");
         }
         return schedule(DIFF_DOCUMENTS, () ->

--- a/src/main/java/ch/sbb/polarion/extension/diff_tool/rest/model/BaseDocumentIdentifier.java
+++ b/src/main/java/ch/sbb/polarion/extension/diff_tool/rest/model/BaseDocumentIdentifier.java
@@ -5,6 +5,8 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.Objects;
+
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
@@ -18,4 +20,14 @@ public class BaseDocumentIdentifier {
 
     @Schema(description = "Name of the document")
     private String name;
+
+    /**
+     * Returns true when both identifiers point to the same document (regardless of revision).
+     */
+    public boolean pointsToSameDocumentAs(BaseDocumentIdentifier other) {
+        return other != null
+                && Objects.equals(projectId, other.projectId)
+                && Objects.equals(spaceId, other.spaceId)
+                && Objects.equals(name, other.name);
+    }
 }

--- a/src/main/java/ch/sbb/polarion/extension/diff_tool/service/CalculatePairsContext.java
+++ b/src/main/java/ch/sbb/polarion/extension/diff_tool/service/CalculatePairsContext.java
@@ -7,6 +7,7 @@ import com.polarion.alm.tracker.model.IWorkItem;
 import com.polarion.platform.persistence.IEnumOption;
 import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.HashMap;
 import java.util.List;
@@ -26,11 +27,12 @@ public class CalculatePairsContext {
     private final List<IWorkItem> leftDocumentWorkItems;
     @Getter
     private final List<IWorkItem> rightDocumentWorkItems;
+    @Nullable
     private final ILinkRoleOpt linkedByRole;
     private final List<String> statusesToIgnore;
     private final Map<IWorkItem, String> outlineNumbersCache = new HashMap<>();
 
-    public CalculatePairsContext(@NotNull IModule leftDocument, @NotNull IModule rightDocument, @NotNull ILinkRoleOpt linkedByRole, @NotNull List<String> statusesToIgnore) {
+    public CalculatePairsContext(@NotNull IModule leftDocument, @NotNull IModule rightDocument, @Nullable ILinkRoleOpt linkedByRole, @NotNull List<String> statusesToIgnore) {
         this.leftDocument = leftDocument;
         this.rightDocument = rightDocument;
         this.linkedByRole = linkedByRole;
@@ -48,7 +50,7 @@ public class CalculatePairsContext {
     }
 
     public boolean isSuitableLinkRole(ILinkRoleOpt roleOpt) {
-        return Objects.equals(linkedByRole.getId(), roleOpt.getId());
+        return linkedByRole != null && Objects.equals(linkedByRole.getId(), roleOpt.getId());
     }
 
     public boolean hasStatusToIgnore(IWorkItem workItem) {

--- a/src/main/java/ch/sbb/polarion/extension/diff_tool/service/DiffService.java
+++ b/src/main/java/ch/sbb/polarion/extension/diff_tool/service/DiffService.java
@@ -83,6 +83,7 @@ public class DiffService {
 
     private static final CharSequence DAISY_DIFF_CHANGED_FRAGMENT = "class=\"diff-html-";
     private static final String INVALID_ROLE_ID_MESSAGE = "No link role could be found by ID '%s'";
+    private static final String MISSING_ROLE_ID_MESSAGE = "Parameter 'linkRole' is required when comparing different documents";
     private final PolarionService polarionService;
 
     // We will execute diff operation twice: using direct & reverse order.
@@ -194,7 +195,7 @@ public class DiffService {
             if (leftDocumentIdentifier.pointsToSameDocumentAs(rightDocumentIdentifier)) {
                 return null;
             }
-            throw new IllegalArgumentException(String.format(INVALID_ROLE_ID_MESSAGE, linkRoleId));
+            throw new IllegalArgumentException(MISSING_ROLE_ID_MESSAGE);
         }
         ILinkRoleOpt linkRole = polarionService.getLinkRoleById(linkRoleId, leftDocument.getProject());
         if (linkRole == null) {

--- a/src/main/java/ch/sbb/polarion/extension/diff_tool/service/DiffService.java
+++ b/src/main/java/ch/sbb/polarion/extension/diff_tool/service/DiffService.java
@@ -110,13 +110,9 @@ public class DiffService {
     public DocumentsContentDiff getDocumentsContentDiff(DocumentIdentifier leftDocumentIdentifier, DocumentIdentifier rightDocumentIdentifier, String linkRoleId) {
         IModule leftDocument = polarionService.getDocumentWithFilledRevision(leftDocumentIdentifier.getProjectId(), leftDocumentIdentifier.getSpaceId(),
                 leftDocumentIdentifier.getName(), leftDocumentIdentifier.getRevision());
-        ILinkRoleOpt linkRole = polarionService.getLinkRoleById(linkRoleId, leftDocument.getProject());
-        if (linkRole == null) {
-            throw new IllegalArgumentException(String.format(INVALID_ROLE_ID_MESSAGE, linkRoleId));
-        }
-
         IModule rightDocument = polarionService.getDocumentWithFilledRevision(rightDocumentIdentifier.getProjectId(), rightDocumentIdentifier.getSpaceId(),
                 rightDocumentIdentifier.getName(), rightDocumentIdentifier.getRevision());
+        ILinkRoleOpt linkRole = resolveLinkRole(linkRoleId, leftDocument, leftDocumentIdentifier, rightDocumentIdentifier);
 
         List<WorkItemsPair> pairedWorkItems = polarionService.getPairedWorkItems(leftDocument, rightDocument, linkRole, Collections.emptyList());
         List<DocumentContentAnchorsPair> pairedDocumentContentAnchors = getPairedDocumentContentAnchors(leftDocument, rightDocument, pairedWorkItems);
@@ -169,13 +165,9 @@ public class DiffService {
     public DocumentsDiff getDocumentsDiff(DocumentIdentifier leftDocumentIdentifier, DocumentIdentifier rightDocumentIdentifier, String linkRoleId, String configName, String configCacheBucketId) {
         IModule leftDocument = polarionService.getDocumentWithFilledRevision(leftDocumentIdentifier.getProjectId(), leftDocumentIdentifier.getSpaceId(),
                 leftDocumentIdentifier.getName(), leftDocumentIdentifier.getRevision());
-        ILinkRoleOpt linkRole = polarionService.getLinkRoleById(linkRoleId, leftDocument.getProject());
-        if (linkRole == null) {
-            throw new IllegalArgumentException(String.format(INVALID_ROLE_ID_MESSAGE, linkRoleId));
-        }
-
         IModule rightDocument = polarionService.getDocumentWithFilledRevision(rightDocumentIdentifier.getProjectId(), rightDocumentIdentifier.getSpaceId(),
                 rightDocumentIdentifier.getName(), rightDocumentIdentifier.getRevision());
+        ILinkRoleOpt linkRole = resolveLinkRole(linkRoleId, leftDocument, leftDocumentIdentifier, rightDocumentIdentifier);
 
         DiffModel diffModel = DiffModelCachedResource.get(leftDocumentIdentifier.getProjectId(), configName, configCacheBucketId);
 
@@ -191,6 +183,24 @@ public class DiffService {
                 .rightDocument(Document.from(rightDocument).authorizedForMerge(polarionService.userAuthorizedForMerge(rightDocumentIdentifier.getProjectId())))
                 .pairedWorkItems(pairedWorkItems)
                 .build();
+    }
+
+    @Nullable
+    private ILinkRoleOpt resolveLinkRole(@Nullable String linkRoleId, @NotNull IModule leftDocument,
+                                         @NotNull DocumentIdentifier leftDocumentIdentifier, @NotNull DocumentIdentifier rightDocumentIdentifier) {
+        // When comparing different revisions of the same document, work items are paired by ID directly,
+        // so a link role is not needed (and the UI doesn't supply one).
+        if (linkRoleId == null || linkRoleId.isEmpty()) {
+            if (leftDocumentIdentifier.pointsToSameDocumentAs(rightDocumentIdentifier)) {
+                return null;
+            }
+            throw new IllegalArgumentException(String.format(INVALID_ROLE_ID_MESSAGE, linkRoleId));
+        }
+        ILinkRoleOpt linkRole = polarionService.getLinkRoleById(linkRoleId, leftDocument.getProject());
+        if (linkRole == null) {
+            throw new IllegalArgumentException(String.format(INVALID_ROLE_ID_MESSAGE, linkRoleId));
+        }
+        return linkRole;
     }
 
     List<WorkItemsPair> handleMovedItems(@NotNull List<WorkItemsPair> pairedWorkItems) {

--- a/src/main/java/ch/sbb/polarion/extension/diff_tool/service/PolarionService.java
+++ b/src/main/java/ch/sbb/polarion/extension/diff_tool/service/PolarionService.java
@@ -309,7 +309,7 @@ public class PolarionService extends ch.sbb.polarion.extension.generic.service.P
     }
 
     @SneakyThrows
-    public List<WorkItemsPair> getPairedWorkItems(@NotNull IModule leftDocument, @NotNull IModule rightDocument, @NotNull ILinkRoleOpt linkRole, @NotNull List<String> statusesToIgnore) {
+    public List<WorkItemsPair> getPairedWorkItems(@NotNull IModule leftDocument, @NotNull IModule rightDocument, @Nullable ILinkRoleOpt linkRole, @NotNull List<String> statusesToIgnore) {
         CalculatePairsContext context = new CalculatePairsContext(leftDocument, rightDocument, linkRole, statusesToIgnore);
 
         // First we need to use sets for both direct and inverse pairs to exclude duplications
@@ -520,7 +520,11 @@ public class PolarionService extends ch.sbb.polarion.extension.generic.service.P
     }
 
     @SuppressWarnings("squid:S1166") // Initial exception swallowed intentionally
-    public List<IWorkItem> getPairedWorkItems(@NotNull IWorkItem toWorkItem, @NotNull String targetProjectId, @NotNull String linkRoleId) {
+    public List<IWorkItem> getPairedWorkItems(@NotNull IWorkItem toWorkItem, @NotNull String targetProjectId, @Nullable String linkRoleId) {
+        if (linkRoleId == null) {
+            // No link role means no cross-document pairing — used when comparing different revisions of the same document.
+            return Collections.emptyList();
+        }
         return Stream.concat(toWorkItem.getLinkedWorkItemsStructsDirect().stream(), toWorkItem.getLinkedWorkItemsStructsBack().stream())
                 .filter(linkedWorkItemStruct -> linkedWorkItemStruct.getLinkRole() != null && linkedWorkItemStruct.getLinkRole().getId().equals(linkRoleId))
                 .map(linkedWorkItemStruct -> {

--- a/src/main/resources/webapp/diff-tool/js/modules/DiffTool.js
+++ b/src/main/resources/webapp/diff-tool/js/modules/DiffTool.js
@@ -205,13 +205,16 @@ export default class DiffTool extends GenericMixin {
     const targetSpace = sameDoc ? this.sourceSpace : this.ctx.getValue("comparison-space-selector");
     const targetDocument = sameDoc ? this.sourceDocument : this.ctx.getValue("document-selector");
     const targetRevision = this.ctx.getValue(this.manualRevision() ? "select-revision-manual-input" : "revision-selector");
-    const linkRole = this.ctx.getValue("comparison-link-role-selector");
+    const linkRole = sameDoc ? "" : this.ctx.getValue("comparison-link-role-selector");
     const config = this.ctx.getValue("comparison-config-selector");
 
     let path = `/polarion/diff-tool-app/ui/app/documents.html`
         + `?sourceProjectId=${this.sourceProjectId}&sourceSpaceId=${this.sourceSpace}&sourceDocument=${this.sourceDocument}`
         + `&targetProjectId=${targetProjectId}&targetSpaceId=${targetSpace}&targetDocument=${targetDocument}`
-        + `&linkRole=${linkRole}&config=${config}&compareAs=Workitems`;
+        + `&config=${config}&compareAs=Workitems`;
+    if (linkRole) {
+        path += `&linkRole=${linkRole}`;
+    }
     if (this.sourceRevision) {
       path += `&sourceRevision=${this.sourceRevision}`;
     }

--- a/src/test/java/ch/sbb/polarion/extension/diff_tool/rest/controller/DiffInternalControllerTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/diff_tool/rest/controller/DiffInternalControllerTest.java
@@ -1,0 +1,111 @@
+package ch.sbb.polarion.extension.diff_tool.rest.controller;
+
+import ch.sbb.polarion.extension.diff_tool.rest.DiffToolRestApplication;
+import ch.sbb.polarion.extension.diff_tool.rest.model.DocumentIdentifier;
+import ch.sbb.polarion.extension.diff_tool.rest.model.diff.DocumentsDiff;
+import ch.sbb.polarion.extension.diff_tool.rest.model.diff.DocumentsDiffParams;
+import ch.sbb.polarion.extension.diff_tool.service.DiffService;
+import ch.sbb.polarion.extension.diff_tool.service.PolarionService;
+import ch.sbb.polarion.extension.diff_tool.service.queue.ExecutionQueueService;
+import ch.sbb.polarion.extension.diff_tool.service.queue.FeatureExecutionTask;
+import ch.sbb.polarion.extension.diff_tool.util.TestUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
+
+import javax.ws.rs.BadRequestException;
+import java.lang.reflect.Field;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+class DiffInternalControllerTest {
+
+    private DiffInternalController controller;
+    private DiffService diffService;
+    private MockedConstruction<PolarionService> polarionServiceConstruction;
+    private MockedStatic<DiffToolRestApplication> mockedApp;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        polarionServiceConstruction = TestUtils.mockPolarionServiceConstruction();
+
+        ExecutionQueueService queue = mock(ExecutionQueueService.class);
+        lenient().when(queue.executeAndWait(any(FeatureExecutionTask.class))).thenAnswer(inv -> {
+            FeatureExecutionTask<?> task = inv.getArgument(0);
+            return task.getTask().call();
+        });
+
+        mockedApp = mockStatic(DiffToolRestApplication.class);
+        mockedApp.when(DiffToolRestApplication::getExecutionService).thenReturn(queue);
+
+        controller = new DiffInternalController();
+
+        diffService = mock(DiffService.class);
+        Field diffServiceField = DiffInternalController.class.getDeclaredField("diffService");
+        diffServiceField.setAccessible(true);
+        diffServiceField.set(controller, diffService);
+    }
+
+    @AfterEach
+    void tearDown() {
+        polarionServiceConstruction.close();
+        mockedApp.close();
+    }
+
+    @Test
+    void getDocumentsDiffThrowsWhenParamsNull() {
+        assertThrows(BadRequestException.class, () -> controller.getDocumentsDiff(null));
+    }
+
+    @Test
+    void getDocumentsDiffThrowsWhenLeftDocumentMissing() {
+        DocumentsDiffParams params = new DocumentsDiffParams(null, mock(DocumentIdentifier.class), "role", null, null);
+        assertThrows(BadRequestException.class, () -> controller.getDocumentsDiff(params));
+    }
+
+    @Test
+    void getDocumentsDiffThrowsWhenRightDocumentMissing() {
+        DocumentsDiffParams params = new DocumentsDiffParams(mock(DocumentIdentifier.class), null, "role", null, null);
+        assertThrows(BadRequestException.class, () -> controller.getDocumentsDiff(params));
+    }
+
+    @Test
+    void getDocumentsDiffThrowsWhenLinkRoleMissingForDifferentDocuments() {
+        DocumentIdentifier left = DocumentIdentifier.builder().projectId("p").spaceId("s").name("a").build();
+        DocumentIdentifier right = DocumentIdentifier.builder().projectId("p").spaceId("s").name("b").build();
+        DocumentsDiffParams params = new DocumentsDiffParams(left, right, null, null, null);
+        assertThrows(BadRequestException.class, () -> controller.getDocumentsDiff(params));
+    }
+
+    @Test
+    void getDocumentsDiffAllowsMissingLinkRoleWhenSameDocument() {
+        DocumentIdentifier left = DocumentIdentifier.builder().projectId("p").spaceId("s").name("doc").revision("r1").build();
+        DocumentIdentifier right = DocumentIdentifier.builder().projectId("p").spaceId("s").name("doc").revision("r2").build();
+        DocumentsDiffParams params = new DocumentsDiffParams(left, right, null, null, null);
+
+        DocumentsDiff expected = DocumentsDiff.builder().build();
+        when(diffService.getDocumentsDiff(any(), any(), any(), any(), any())).thenReturn(expected);
+
+        assertNotNull(controller.getDocumentsDiff(params));
+    }
+
+    @Test
+    void getDocumentsDiffPassesValidLinkRoleThrough() {
+        DocumentIdentifier left = DocumentIdentifier.builder().projectId("pA").spaceId("s").name("doc").build();
+        DocumentIdentifier right = DocumentIdentifier.builder().projectId("pB").spaceId("s").name("doc").build();
+        DocumentsDiffParams params = new DocumentsDiffParams(left, right, "relates-to", null, null);
+
+        DocumentsDiff expected = DocumentsDiff.builder().build();
+        when(diffService.getDocumentsDiff(any(), any(), any(), any(), any())).thenReturn(expected);
+
+        assertNotNull(controller.getDocumentsDiff(params));
+    }
+}

--- a/src/test/java/ch/sbb/polarion/extension/diff_tool/rest/model/BaseDocumentIdentifierTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/diff_tool/rest/model/BaseDocumentIdentifierTest.java
@@ -1,0 +1,43 @@
+package ch.sbb.polarion.extension.diff_tool.rest.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class BaseDocumentIdentifierTest {
+
+    @Test
+    void pointsToSameDocumentAsReturnsTrueForIdenticalIdentifiers() {
+        BaseDocumentIdentifier a = new BaseDocumentIdentifier("p", "s", "doc");
+        BaseDocumentIdentifier b = new BaseDocumentIdentifier("p", "s", "doc");
+        assertTrue(a.pointsToSameDocumentAs(b));
+    }
+
+    @Test
+    void pointsToSameDocumentAsReturnsFalseWhenProjectDiffers() {
+        BaseDocumentIdentifier a = new BaseDocumentIdentifier("pA", "s", "doc");
+        BaseDocumentIdentifier b = new BaseDocumentIdentifier("pB", "s", "doc");
+        assertFalse(a.pointsToSameDocumentAs(b));
+    }
+
+    @Test
+    void pointsToSameDocumentAsReturnsFalseWhenSpaceDiffers() {
+        BaseDocumentIdentifier a = new BaseDocumentIdentifier("p", "sA", "doc");
+        BaseDocumentIdentifier b = new BaseDocumentIdentifier("p", "sB", "doc");
+        assertFalse(a.pointsToSameDocumentAs(b));
+    }
+
+    @Test
+    void pointsToSameDocumentAsReturnsFalseWhenNameDiffers() {
+        BaseDocumentIdentifier a = new BaseDocumentIdentifier("p", "s", "left");
+        BaseDocumentIdentifier b = new BaseDocumentIdentifier("p", "s", "right");
+        assertFalse(a.pointsToSameDocumentAs(b));
+    }
+
+    @Test
+    void pointsToSameDocumentAsReturnsFalseForNull() {
+        BaseDocumentIdentifier a = new BaseDocumentIdentifier("p", "s", "doc");
+        assertFalse(a.pointsToSameDocumentAs(null));
+    }
+}

--- a/src/test/java/ch/sbb/polarion/extension/diff_tool/service/CalculatePairsContextTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/diff_tool/service/CalculatePairsContextTest.java
@@ -1,0 +1,48 @@
+package ch.sbb.polarion.extension.diff_tool.service;
+
+import com.polarion.alm.tracker.model.ILinkRoleOpt;
+import com.polarion.alm.tracker.model.IModule;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class CalculatePairsContextTest {
+
+    @Test
+    void isSuitableLinkRoleReturnsFalseWhenLinkedByRoleIsNull() {
+        IModule leftDocument = mock(IModule.class);
+        when(leftDocument.getAllWorkItems()).thenReturn(Collections.emptyList());
+        IModule rightDocument = mock(IModule.class);
+        when(rightDocument.getAllWorkItems()).thenReturn(Collections.emptyList());
+
+        CalculatePairsContext context = new CalculatePairsContext(leftDocument, rightDocument, null, Collections.emptyList());
+
+        ILinkRoleOpt anyRole = mock(ILinkRoleOpt.class);
+        assertFalse(context.isSuitableLinkRole(anyRole));
+    }
+
+    @Test
+    void isSuitableLinkRoleMatchesById() {
+        IModule leftDocument = mock(IModule.class);
+        when(leftDocument.getAllWorkItems()).thenReturn(Collections.emptyList());
+        IModule rightDocument = mock(IModule.class);
+        when(rightDocument.getAllWorkItems()).thenReturn(Collections.emptyList());
+
+        ILinkRoleOpt linkedByRole = mock(ILinkRoleOpt.class);
+        when(linkedByRole.getId()).thenReturn("relates-to");
+        CalculatePairsContext context = new CalculatePairsContext(leftDocument, rightDocument, linkedByRole, Collections.emptyList());
+
+        ILinkRoleOpt sameId = mock(ILinkRoleOpt.class);
+        when(sameId.getId()).thenReturn("relates-to");
+        ILinkRoleOpt otherId = mock(ILinkRoleOpt.class);
+        when(otherId.getId()).thenReturn("blocks");
+
+        assertTrue(context.isSuitableLinkRole(sameId));
+        assertFalse(context.isSuitableLinkRole(otherId));
+    }
+}

--- a/src/test/java/ch/sbb/polarion/extension/diff_tool/service/DiffServiceTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/diff_tool/service/DiffServiceTest.java
@@ -931,10 +931,12 @@ class DiffServiceTest {
     @Test
     void testGetDocumentsDiffThrowsExceptionForInvalidLinkRole() {
         IModule leftDocument = mock(IModule.class);
+        IModule rightDocument = mock(IModule.class);
         ITrackerProject trackerProject = mock(ITrackerProject.class);
         when(leftDocument.getProject()).thenReturn(trackerProject);
 
         when(polarionService.getDocumentWithFilledRevision("project1", "space1", "left", "rev1")).thenReturn(leftDocument);
+        when(polarionService.getDocumentWithFilledRevision("project1", "space1", "right", "rev1")).thenReturn(rightDocument);
         when(polarionService.getLinkRoleById("invalid-role", trackerProject)).thenReturn(null);
 
         DocumentIdentifier leftDocumentIdentifier = DocumentIdentifier.builder().projectId("project1").spaceId("space1").name("left").revision("rev1").build();
@@ -944,6 +946,125 @@ class DiffServiceTest {
                 diffService.getDocumentsDiff(leftDocumentIdentifier, rightDocumentIdentifier, "invalid-role", null, null));
 
         assertTrue(exception.getMessage().contains("invalid-role"));
+    }
+
+    @Test
+    void testGetDocumentsDiffThrowsForMissingLinkRoleWhenDocumentsDiffer() {
+        IModule leftDocument = mock(IModule.class);
+        IModule rightDocument = mock(IModule.class);
+        when(polarionService.getDocumentWithFilledRevision("project1", "space1", "left", "rev1")).thenReturn(leftDocument);
+        when(polarionService.getDocumentWithFilledRevision("project1", "space1", "right", "rev1")).thenReturn(rightDocument);
+
+        DocumentIdentifier leftDocumentIdentifier = DocumentIdentifier.builder().projectId("project1").spaceId("space1").name("left").revision("rev1").build();
+        DocumentIdentifier rightDocumentIdentifier = DocumentIdentifier.builder().projectId("project1").spaceId("space1").name("right").revision("rev1").build();
+
+        assertThrows(IllegalArgumentException.class, () ->
+                diffService.getDocumentsDiff(leftDocumentIdentifier, rightDocumentIdentifier, null, null, null));
+        assertThrows(IllegalArgumentException.class, () ->
+                diffService.getDocumentsDiff(leftDocumentIdentifier, rightDocumentIdentifier, "", null, null));
+        verify(polarionService, never()).getLinkRoleById(anyString(), any());
+    }
+
+    @Test
+    void testGetDocumentsDiffAllowsMissingLinkRoleForSameDocument() {
+        IModule document = mockSameDocumentForDiff();
+
+        when(polarionService.getDocumentWithFilledRevision("project1", "space1", "doc", "rev1")).thenReturn(document);
+        when(polarionService.getDocumentWithFilledRevision("project1", "space1", "doc", "rev2")).thenReturn(document);
+        when(polarionService.getPairedWorkItems(eq(document), eq(document), isNull(), anyList())).thenReturn(Collections.emptyList());
+        when(polarionService.getDocumentWorkItemsCache()).thenReturn(mock(ch.sbb.polarion.extension.diff_tool.util.DocumentWorkItemsCache.class));
+
+        DocumentIdentifier leftDocumentIdentifier = DocumentIdentifier.builder().projectId("project1").spaceId("space1").name("doc").revision("rev1").build();
+        DocumentIdentifier rightDocumentIdentifier = DocumentIdentifier.builder().projectId("project1").spaceId("space1").name("doc").revision("rev2").build();
+
+        org.springframework.web.context.request.ServletRequestAttributes attrs =
+                mock(org.springframework.web.context.request.ServletRequestAttributes.class);
+        when(attrs.getRequest()).thenReturn(mock(javax.servlet.http.HttpServletRequest.class));
+        org.springframework.web.context.request.RequestContextHolder.setRequestAttributes(attrs);
+        try (org.mockito.MockedStatic<ch.sbb.polarion.extension.diff_tool.util.DiffModelCachedResource> mockedDiffModel =
+                     mockStatic(ch.sbb.polarion.extension.diff_tool.util.DiffModelCachedResource.class)) {
+            mockedDiffModel.when(() -> ch.sbb.polarion.extension.diff_tool.util.DiffModelCachedResource.get(any(), any(), any()))
+                    .thenReturn(ch.sbb.polarion.extension.diff_tool.rest.model.settings.DiffModel.builder().build());
+            assertNotNull(diffService.getDocumentsDiff(leftDocumentIdentifier, rightDocumentIdentifier, null, null, null));
+            assertNotNull(diffService.getDocumentsDiff(leftDocumentIdentifier, rightDocumentIdentifier, "", null, null));
+        } finally {
+            org.springframework.web.context.request.RequestContextHolder.resetRequestAttributes();
+        }
+        // No link role lookup must happen for same-document compare with empty linkRoleId.
+        verify(polarionService, never()).getLinkRoleById(anyString(), any());
+    }
+
+    @Test
+    void testGetDocumentsDiffRequiresLinkRoleWhenProjectDiffers() {
+        IModule leftDocument = mock(IModule.class);
+        IModule rightDocument = mock(IModule.class);
+        when(polarionService.getDocumentWithFilledRevision("projectA", "space1", "doc", null)).thenReturn(leftDocument);
+        when(polarionService.getDocumentWithFilledRevision("projectB", "space1", "doc", null)).thenReturn(rightDocument);
+
+        DocumentIdentifier left = DocumentIdentifier.builder().projectId("projectA").spaceId("space1").name("doc").build();
+        DocumentIdentifier right = DocumentIdentifier.builder().projectId("projectB").spaceId("space1").name("doc").build();
+
+        assertThrows(IllegalArgumentException.class, () -> diffService.getDocumentsDiff(left, right, null, null, null));
+    }
+
+    @Test
+    void testGetDocumentsDiffRequiresLinkRoleWhenSpaceDiffers() {
+        IModule leftDocument = mock(IModule.class);
+        IModule rightDocument = mock(IModule.class);
+        when(polarionService.getDocumentWithFilledRevision("project1", "space1", "doc", null)).thenReturn(leftDocument);
+        when(polarionService.getDocumentWithFilledRevision("project1", "space2", "doc", null)).thenReturn(rightDocument);
+
+        DocumentIdentifier left = DocumentIdentifier.builder().projectId("project1").spaceId("space1").name("doc").build();
+        DocumentIdentifier right = DocumentIdentifier.builder().projectId("project1").spaceId("space2").name("doc").build();
+
+        // Same project + name, but different space ⇒ documents differ ⇒ linkRole still required.
+        assertThrows(IllegalArgumentException.class, () -> diffService.getDocumentsDiff(left, right, null, null, null));
+    }
+
+    @Test
+    void testGetDocumentsDiffRequiresLinkRoleWhenNameDiffers() {
+        IModule leftDocument = mock(IModule.class);
+        IModule rightDocument = mock(IModule.class);
+        when(polarionService.getDocumentWithFilledRevision("project1", "space1", "left", null)).thenReturn(leftDocument);
+        when(polarionService.getDocumentWithFilledRevision("project1", "space1", "right", null)).thenReturn(rightDocument);
+
+        DocumentIdentifier left = DocumentIdentifier.builder().projectId("project1").spaceId("space1").name("left").build();
+        DocumentIdentifier right = DocumentIdentifier.builder().projectId("project1").spaceId("space1").name("right").build();
+
+        // Same project + space, but different name ⇒ documents differ ⇒ linkRole still required.
+        assertThrows(IllegalArgumentException.class, () -> diffService.getDocumentsDiff(left, right, null, null, null));
+    }
+
+    @Test
+    void testGetDocumentsContentDiffAllowsMissingLinkRoleForSameDocument() {
+        IModule document = mockSameDocumentForDiff();
+        when(document.getHomePageContent()).thenReturn(Text.html(""));
+
+        when(polarionService.getDocumentWithFilledRevision("project1", "space1", "doc", "rev1")).thenReturn(document);
+        when(polarionService.getDocumentWithFilledRevision("project1", "space1", "doc", "rev2")).thenReturn(document);
+        when(polarionService.getPairedWorkItems(eq(document), eq(document), isNull(), anyList())).thenReturn(Collections.emptyList());
+
+        DocumentIdentifier leftDocumentIdentifier = DocumentIdentifier.builder().projectId("project1").spaceId("space1").name("doc").revision("rev1").build();
+        DocumentIdentifier rightDocumentIdentifier = DocumentIdentifier.builder().projectId("project1").spaceId("space1").name("doc").revision("rev2").build();
+
+        assertNotNull(diffService.getDocumentsContentDiff(leftDocumentIdentifier, rightDocumentIdentifier, null));
+        verify(polarionService, never()).getLinkRoleById(anyString(), any());
+    }
+
+    private IModule mockSameDocumentForDiff() {
+        IModule document = mock(IModule.class);
+        lenient().when(document.getProjectId()).thenReturn("project1");
+        IDataService dataService = mock(IDataService.class);
+        IRevision revision = mock(IRevision.class);
+        lenient().when(revision.getName()).thenReturn("1");
+        when(dataService.getLastStorageRevision()).thenReturn(revision);
+        when(document.getDataSvc()).thenReturn(dataService);
+        ILocation moduleLocation = mock(ILocation.class);
+        when(document.getModuleLocation()).thenReturn(moduleLocation);
+        ITrackerProject trackerProject = mock(ITrackerProject.class);
+        lenient().when(trackerProject.getId()).thenReturn("project1");
+        lenient().when(document.getProject()).thenReturn(trackerProject);
+        return document;
     }
 
     // ==================== getCollectionsDiff() method tests ====================

--- a/src/test/java/ch/sbb/polarion/extension/diff_tool/service/PolarionServiceTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/diff_tool/service/PolarionServiceTest.java
@@ -1022,6 +1022,18 @@ class PolarionServiceTest {
         assertTrue(result.isEmpty());
     }
 
+    @Test
+    void testGetPairedWorkItemsWithNullLinkRoleIdReturnsEmpty() {
+        // No link role means no cross-document pairing — used when comparing different revisions of the same document.
+        IWorkItem sourceWorkItem = mock(IWorkItem.class);
+
+        List<IWorkItem> result = polarionService.getPairedWorkItems(sourceWorkItem, "targetProject", null);
+
+        assertTrue(result.isEmpty());
+        verify(sourceWorkItem, never()).getLinkedWorkItemsStructsDirect();
+        verify(sourceWorkItem, never()).getLinkedWorkItemsStructsBack();
+    }
+
     private IModule mockDocument(String name, Date created) {
         IModule document = mock(IModule.class);
         lenient().when(document.getProjectId()).thenReturn(PROJECT_ID);

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -676,9 +676,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -694,9 +691,6 @@
       "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -714,9 +708,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -732,9 +723,6 @@
       "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -752,9 +740,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -770,9 +755,6 @@
       "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -790,9 +772,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -809,9 +788,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -827,9 +803,6 @@
       "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -853,9 +826,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -877,9 +847,6 @@
       "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -903,9 +870,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -927,9 +891,6 @@
       "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -953,9 +914,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -978,9 +936,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1002,9 +957,6 @@
       "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1298,9 +1250,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1316,9 +1265,6 @@
       "integrity": "sha512-iVMMp14514u7Nup2umQS03nT/bN9HurK8ufylC3FZNykrwjtx7V1A7+4kvhbDSCeonTVqV3Txnv0Lu+m2oDXNg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1336,9 +1282,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1354,9 +1297,6 @@
       "integrity": "sha512-h9FxsngCm9cTBf71AR4fGznDEDx1hS7+kSEiIRjq5kO1oXWm07DxVGZjCvk0SGx7TSjlUqhI8oOyz7NfwAdPoA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1888,9 +1828,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1905,9 +1842,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1922,9 +1856,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1939,9 +1870,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1956,9 +1884,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1973,9 +1898,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1990,9 +1912,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2007,9 +1926,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3753,6 +3669,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/ui/src/components/documents/DocumentsDiff.js
+++ b/ui/src/components/documents/DocumentsDiff.js
@@ -26,9 +26,13 @@ import * as DiffTypes from "@/DiffTypes";
 const REQUIRED_PARAMS = ['sourceProjectId', 'sourceSpaceId', 'sourceDocument', 'targetProjectId', 'targetSpaceId', 'targetDocument'];
 
 const isSameDocument = (searchParams) => {
-  return searchParams.get('sourceProjectId') === searchParams.get('targetProjectId')
-      && searchParams.get('sourceSpaceId') === searchParams.get('targetSpaceId')
-      && searchParams.get('sourceDocument') === searchParams.get('targetDocument');
+  const sourceProjectId = searchParams.get('sourceProjectId');
+  const sourceSpaceId = searchParams.get('sourceSpaceId');
+  const sourceDocument = searchParams.get('sourceDocument');
+  return Boolean(sourceProjectId && sourceSpaceId && sourceDocument)
+      && sourceProjectId === searchParams.get('targetProjectId')
+      && sourceSpaceId === searchParams.get('targetSpaceId')
+      && sourceDocument === searchParams.get('targetDocument');
 };
 const PAIRS_COUNT_TO_ASK_SWAP_CONFIRMATION = 200; // Threshold above which a diff reload takes relatively long — prompt the user for confirmation beyond this limit.
 

--- a/ui/src/components/documents/DocumentsDiff.js
+++ b/ui/src/components/documents/DocumentsDiff.js
@@ -23,7 +23,13 @@ import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import useSwapDocuments from "@/utils/useSwapDocuments";
 import * as DiffTypes from "@/DiffTypes";
 
-const REQUIRED_PARAMS = ['sourceProjectId', 'sourceSpaceId', 'sourceDocument', 'targetProjectId', 'targetSpaceId', 'targetDocument', 'linkRole'];
+const REQUIRED_PARAMS = ['sourceProjectId', 'sourceSpaceId', 'sourceDocument', 'targetProjectId', 'targetSpaceId', 'targetDocument'];
+
+const isSameDocument = (searchParams) => {
+  return searchParams.get('sourceProjectId') === searchParams.get('targetProjectId')
+      && searchParams.get('sourceSpaceId') === searchParams.get('targetSpaceId')
+      && searchParams.get('sourceDocument') === searchParams.get('targetDocument');
+};
 const PAIRS_COUNT_TO_ASK_SWAP_CONFIRMATION = 200; // Threshold above which a diff reload takes relatively long — prompt the user for confirmation beyond this limit.
 
 export default function DocumentsDiff({ enclosingCollections }) {
@@ -50,7 +56,8 @@ export default function DocumentsDiff({ enclosingCollections }) {
   const [swapConfirmModalVisible, setSwapConfirmModalVisible] = useState(false);
 
   useEffect(() => {
-    const missingParams = REQUIRED_PARAMS.filter(param => !searchParams.get(param));
+    const requiredParams = isSameDocument(searchParams) ? REQUIRED_PARAMS : [...REQUIRED_PARAMS, 'linkRole'];
+    const missingParams = requiredParams.filter(param => !searchParams.get(param));
     if (missingParams.length > 0) {
       loadingContext.pairsLoadingFinishedWithError(`Following parameters are missing: [${missingParams.join(", ")}]`);
       return;


### PR DESCRIPTION
### Proposed changes

This pull request refactors how the diff tool handles the `linkRole` parameter when comparing documents, allowing it to be omitted when comparing different revisions of the same document (i.e., the same document with different revisions). It also introduces new tests to ensure this behavior is correct and robust. The main changes involve backend logic, API validation, and frontend parameter handling.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation
