### PR TITLE
fix: Get rid of duplicated field definitions in case of the same custom field on global and wi level

### DIFF
--- a/src/main/java/ch/sbb/polarion/extension/diff_tool/rest/controller/UtilityApiController.java
+++ b/src/main/java/ch/sbb/polarion/extension/diff_tool/rest/controller/UtilityApiController.java
@@ -37,7 +37,7 @@ public class UtilityApiController extends UtilityInternalController {
     }
 
     @Override
-    public List<WorkItemField> getAllWorkItemFields(String projectId) {
+    public Collection<WorkItemField> getAllWorkItemFields(String projectId) {
         return polarionService.callPrivileged(() -> super.getAllWorkItemFields(projectId));
     }
 

--- a/src/main/java/ch/sbb/polarion/extension/diff_tool/rest/controller/UtilityInternalController.java
+++ b/src/main/java/ch/sbb/polarion/extension/diff_tool/rest/controller/UtilityInternalController.java
@@ -158,7 +158,7 @@ public class UtilityInternalController {
                     )
             }
     )
-    public List<WorkItemField> getAllWorkItemFields(@PathParam("projectId") String projectId) {
+    public Collection<WorkItemField> getAllWorkItemFields(@PathParam("projectId") String projectId) {
         if (StringUtils.isBlank(projectId)) {
             throw new BadRequestException(MISSING_PROJECT_ID_MESSAGE);
         }

--- a/src/main/java/ch/sbb/polarion/extension/diff_tool/rest/model/diff/WorkItemField.java
+++ b/src/main/java/ch/sbb/polarion/extension/diff_tool/rest/model/diff/WorkItemField.java
@@ -41,6 +41,18 @@ public class WorkItemField implements Comparable<WorkItemField> {
 
     @Override
     public int compareTo(@NotNull WorkItemField other) {
-        return this.name.compareTo(other.name);
+        int fieldNameDiff = this.name.compareTo(other.name);
+        if (fieldNameDiff != 0) {
+            return fieldNameDiff;
+        } else {
+            if (this.wiTypeName != null && other.wiTypeName != null) {
+                return this.wiTypeName.compareTo(other.wiTypeName);
+            } else if (this.wiTypeName != null) {
+                return 1;
+            } else if (other.wiTypeName != null) {
+                return -1;
+            }
+            return 0;
+        }
     }
 }

--- a/src/main/java/ch/sbb/polarion/extension/diff_tool/rest/model/diff/WorkItemField.java
+++ b/src/main/java/ch/sbb/polarion/extension/diff_tool/rest/model/diff/WorkItemField.java
@@ -7,6 +7,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.VisibleForTesting;
 
 @Data
 @Builder
@@ -57,7 +58,8 @@ public class WorkItemField implements Comparable<WorkItemField> {
         return compareNullable(this.key, other.key);
     }
 
-    private static int compareNullable(String first, String second) {
+    @VisibleForTesting
+    static int compareNullable(String first, String second) {
         if (first != null && second != null) {
             return first.compareTo(second);
         } else if (first != null) {

--- a/src/main/java/ch/sbb/polarion/extension/diff_tool/rest/model/diff/WorkItemField.java
+++ b/src/main/java/ch/sbb/polarion/extension/diff_tool/rest/model/diff/WorkItemField.java
@@ -44,15 +44,27 @@ public class WorkItemField implements Comparable<WorkItemField> {
         int fieldNameDiff = this.name.compareTo(other.name);
         if (fieldNameDiff != 0) {
             return fieldNameDiff;
-        } else {
-            if (this.wiTypeName != null && other.wiTypeName != null) {
-                return this.wiTypeName.compareTo(other.wiTypeName);
-            } else if (this.wiTypeName != null) {
-                return 1;
-            } else if (other.wiTypeName != null) {
-                return -1;
-            }
-            return 0;
         }
+
+        int wiTypeNameDiff = compareNullable(this.wiTypeName, other.wiTypeName);
+        if (wiTypeNameDiff != 0) {
+            return wiTypeNameDiff;
+        }
+
+        // Two fields can share the same name and work item type but still be distinct custom fields with different
+        // keys, so the unique key is used as the final criterion to keep them apart (it stays 0 for the same field
+        // defined both globally and on a work item type, which is what we want to deduplicate).
+        return compareNullable(this.key, other.key);
+    }
+
+    private static int compareNullable(String first, String second) {
+        if (first != null && second != null) {
+            return first.compareTo(second);
+        } else if (first != null) {
+            return 1;
+        } else if (second != null) {
+            return -1;
+        }
+        return 0;
     }
 }

--- a/src/main/java/ch/sbb/polarion/extension/diff_tool/service/MergeService.java
+++ b/src/main/java/ch/sbb/polarion/extension/diff_tool/service/MergeService.java
@@ -818,7 +818,7 @@ public class MergeService {
             ICustomFieldsService customFieldsService = polarionService.getTrackerService().getDataService().getCustomFieldsService();
             ICustomField sourceCustomField = customFieldsService.getCustomField(source, field.getKey());
             ICustomField targetCustomField = customFieldsService.getCustomField(target, field.getKey());
-            if (!sourceCustomField.getType().equals(targetCustomField.getType())) { // ...and if types of this custom field in source and in target items are not equal then throw an error
+            if (!Objects.equals(sourceCustomField.getType().getClass(), targetCustomField.getType().getClass())) { // ...and if types of this custom field in source and in target items are not equal then throw an error
                 throw new IllegalStateException(String.format("Can't merge fields with different types, check that fields with key '%s' have the same type in source and target work item", field.getKey()));
             }
         }

--- a/src/main/java/ch/sbb/polarion/extension/diff_tool/service/MergeService.java
+++ b/src/main/java/ch/sbb/polarion/extension/diff_tool/service/MergeService.java
@@ -1048,7 +1048,7 @@ public class MergeService {
 
     @VisibleForTesting
     void updateAttachmentReferences(IWorkItem target, Map<String, String> fileNamesMapping) {
-        List<WorkItemField> workItemFields = polarionService.getAllWorkItemFields(target.getProjectId());
+        Collection<WorkItemField> workItemFields = polarionService.getAllWorkItemFields(target.getProjectId());
         for (WorkItemField workItemField : workItemFields) {
             Object value = target.getValue(workItemField.getKey());
             if (value instanceof Text text) {

--- a/src/main/java/ch/sbb/polarion/extension/diff_tool/service/PolarionService.java
+++ b/src/main/java/ch/sbb/polarion/extension/diff_tool/service/PolarionService.java
@@ -78,6 +78,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Predicate;
 import java.util.regex.Matcher;
@@ -553,8 +554,8 @@ public class PolarionService extends ch.sbb.polarion.extension.generic.service.P
         });
     }
 
-    public List<WorkItemField> getAllWorkItemFields(@NotNull String projectId) {
-        List<WorkItemField> fields = new ArrayList<>(getStandardFields());
+    public Collection<WorkItemField> getAllWorkItemFields(@NotNull String projectId) {
+        Set<WorkItemField> fields = new TreeSet<>(getStandardFields());
 
         ITrackerProject trackerProject = getTrackerProject(projectId);
         IContextId contextId = trackerProject.getContextId();
@@ -563,7 +564,6 @@ public class PolarionService extends ch.sbb.polarion.extension.generic.service.P
             fields.addAll(getCustomFields(contextId, wiType));
         }
 
-        Collections.sort(fields);
         return fields;
     }
 

--- a/src/test/java/ch/sbb/polarion/extension/diff_tool/rest/model/diff/WorkItemFieldTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/diff_tool/rest/model/diff/WorkItemFieldTest.java
@@ -2,7 +2,11 @@ package ch.sbb.polarion.extension.diff_tool.rest.model.diff;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Set;
+import java.util.TreeSet;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class WorkItemFieldTest {
     @Test
@@ -11,5 +15,39 @@ class WorkItemFieldTest {
         WorkItemField workItemField2 = WorkItemField.builder().name("wi2").build();
 
         assertEquals("wi1".compareTo("wi2"), workItemField1.compareTo(workItemField2));
+    }
+
+    @Test
+    void shouldDistinguishFieldsWithSameNameAndTypeButDifferentKey() {
+        WorkItemField field1 = WorkItemField.builder().key("key1").name("Priority").wiTypeName("Requirement").build();
+        WorkItemField field2 = WorkItemField.builder().key("key2").name("Priority").wiTypeName("Requirement").build();
+
+        assertTrue(field1.compareTo(field2) != 0);
+        assertEquals("key1".compareTo("key2"), field1.compareTo(field2));
+    }
+
+    @Test
+    void shouldTreatSameFieldDefinedGloballyAndOnTypeAsIdentical() {
+        // Same custom field surfaced once globally (no work item type) and once for a specific type: same key
+        WorkItemField globalCopy = WorkItemField.builder().key("custom").name("Custom Field").build();
+        WorkItemField typeCopy = WorkItemField.builder().key("custom").name("Custom Field").wiTypeName("Requirement").build();
+
+        // wiTypeName still differentiates the two copies for ordering, but they remain distinct entries
+        assertTrue(globalCopy.compareTo(typeCopy) != 0);
+    }
+
+    @Test
+    void treeSetShouldKeepDistinctFieldsSharingTheSameName() {
+        WorkItemField field1 = WorkItemField.builder().key("key1").name("Priority").wiTypeName("Requirement").build();
+        WorkItemField field2 = WorkItemField.builder().key("key2").name("Priority").wiTypeName("Requirement").build();
+        WorkItemField duplicateOfField1 = WorkItemField.builder().key("key1").name("Priority").wiTypeName("Requirement").build();
+
+        Set<WorkItemField> fields = new TreeSet<>();
+        fields.add(field1);
+        fields.add(field2);
+        fields.add(duplicateOfField1);
+
+        // The two fields with distinct keys are both retained; the true duplicate (same key/name/type) is discarded
+        assertEquals(2, fields.size());
     }
 }

--- a/src/test/java/ch/sbb/polarion/extension/diff_tool/rest/model/diff/WorkItemFieldTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/diff_tool/rest/model/diff/WorkItemFieldTest.java
@@ -50,4 +50,32 @@ class WorkItemFieldTest {
         // The two fields with distinct keys are both retained; the true duplicate (same key/name/type) is discarded
         assertEquals(2, fields.size());
     }
+
+    @Test
+    void compareNullableShouldReturnZeroWhenBothNull() {
+        assertEquals(0, WorkItemField.compareNullable(null, null));
+    }
+
+    @Test
+    void compareNullableShouldReturnPositiveWhenSecondIsNull() {
+        assertEquals(1, WorkItemField.compareNullable("a", null));
+    }
+
+    @Test
+    void compareNullableShouldReturnNegativeWhenFirstIsNull() {
+        assertEquals(-1, WorkItemField.compareNullable(null, "a"));
+    }
+
+    @Test
+    void compareNullableShouldReturnZeroWhenBothEqual() {
+        assertEquals(0, WorkItemField.compareNullable("a", "a"));
+    }
+
+    @Test
+    void compareNullableShouldDelegateToStringCompareWhenBothNonNull() {
+        assertEquals("a".compareTo("b"), WorkItemField.compareNullable("a", "b"));
+        assertEquals("b".compareTo("a"), WorkItemField.compareNullable("b", "a"));
+        assertTrue(WorkItemField.compareNullable("a", "b") < 0);
+        assertTrue(WorkItemField.compareNullable("b", "a") > 0);
+    }
 }

--- a/src/test/java/ch/sbb/polarion/extension/diff_tool/service/MergeServiceTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/diff_tool/service/MergeServiceTest.java
@@ -1797,10 +1797,10 @@ class MergeServiceTest {
         DocumentIdentifier doc2 = new DocumentIdentifier("project2", "space2", "doc2", "rev1", "rev1");
 
         CustomField sourceCustomFieldMock = mock(CustomField.class);
-        IType sourceTypeMock = mock(IType.class);
+        IType sourceTypeMock = mock(IEnumType.class);
         when(sourceCustomFieldMock.getType()).thenReturn(sourceTypeMock);
         CustomField targetCustomFieldMock = mock(CustomField.class);
-        IType targetTypeMock = mock(IType.class);
+        IType targetTypeMock = mock(IListType.class);
         when(targetCustomFieldMock.getType()).thenReturn(targetTypeMock);
         CustomFieldsService customFieldsServiceMock = mock(CustomFieldsService.class);
         when(customFieldsServiceMock.getCustomField(argThat(obj -> obj instanceof IWorkItem workItem && workItem.getProjectId().equals("project1")), any())).thenReturn(sourceCustomFieldMock);

--- a/src/test/java/ch/sbb/polarion/extension/diff_tool/service/MergeServiceTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/diff_tool/service/MergeServiceTest.java
@@ -1858,6 +1858,73 @@ class MergeServiceTest {
     }
 
     @Test
+    void testCorrespondingFieldTypesDoesNotThrowError() {
+        NamedSettingsRegistry.INSTANCE.register(List.of(new DiffSettings(settingsService)));
+        DocumentIdentifier doc1 = new DocumentIdentifier("project1", "space1", "doc1", "rev1", "rev1");
+        DocumentIdentifier doc2 = new DocumentIdentifier("project2", "space2", "doc2", "rev1", "rev1");
+
+        CustomField sourceCustomFieldMock = mock(CustomField.class);
+        IType sourceTypeMock = mock(IType.class);
+        when(sourceCustomFieldMock.getType()).thenReturn(sourceTypeMock);
+        CustomField targetCustomFieldMock = mock(CustomField.class);
+        IType targetTypeMock = mock(IType.class);
+        when(targetCustomFieldMock.getType()).thenReturn(targetTypeMock);
+        CustomFieldsService customFieldsServiceMock = mock(CustomFieldsService.class);
+        when(customFieldsServiceMock.getCustomField(argThat(obj -> obj instanceof IWorkItem workItem && workItem.getProjectId().equals("project1")), any())).thenReturn(sourceCustomFieldMock);
+        when(customFieldsServiceMock.getCustomField(argThat(obj -> obj instanceof IWorkItem workItem && workItem.getProjectId().equals("project2")), any())).thenReturn(targetCustomFieldMock);
+        IDataService dataServiceMock = mock(IDataService.class);
+        when(dataServiceMock.getCustomFieldsService()).thenReturn(customFieldsServiceMock);
+        ITrackerService trackerServiceMock = mock(ITrackerService.class);
+        when(trackerServiceMock.getDataService()).thenReturn(dataServiceMock);
+        when(polarionService.getTrackerService()).thenReturn(trackerServiceMock);
+
+        IModule leftModule = mock(IModule.class);
+        ILocation leftLocation = mock(ILocation.class);
+        when(leftLocation.getLocationPath()).thenReturn("space1/doc1");
+        when(leftModule.getModuleLocation()).thenReturn(leftLocation);
+        lenient().when(leftModule.getLastRevision()).thenReturn("rev1");
+        when(polarionService.getModule(doc1)).thenReturn(leftModule);
+
+        IModule rightModule = mock(IModule.class);
+        ILocation rightLocation = mock(ILocation.class);
+        when(rightLocation.getLocationPath()).thenReturn("space2/doc2");
+        when(rightModule.getModuleLocation()).thenReturn(rightLocation);
+        lenient().when(rightModule.getLastRevision()).thenReturn("rev1");
+        when(polarionService.getModule(doc2)).thenReturn(rightModule);
+
+        IWorkItem leftWorkItem = mock(IWorkItem.class);
+        when(leftWorkItem.getId()).thenReturn("left");
+        when(leftWorkItem.getProjectId()).thenReturn("project1");
+        when(leftWorkItem.getLastRevision()).thenReturn("rev1");
+        when(leftWorkItem.getPrototype()).thenReturn(mock(IPrototype.class));
+
+        IWorkItem rightWorkItem = mock(IWorkItem.class);
+        when(rightWorkItem.getId()).thenReturn("right");
+        when(rightWorkItem.getProjectId()).thenReturn("project2");
+        when(rightWorkItem.getLastRevision()).thenReturn("rev1");
+
+        List<MergeWorkItemsPair> workItemsPairs = new ArrayList<>();
+        workItemsPairs.add(new MergeWorkItemsPair(leftWorkItem, rightWorkItem, List.of()));
+        DiffModel diffModel = mock(DiffModel.class);
+
+        List<DiffField> diffFields = new ArrayList<>();
+        diffFields.add(DiffField.builder().key("testSteps").build());
+
+        when(diffModel.getDiffFields()).thenReturn(diffFields);
+        when(polarionService.getLinkRoleById(anyString(), any())).thenReturn(mock(ILinkRoleOpt.class));
+        DocumentsMergeParams mergeParams = new DocumentsMergeParams(doc1, doc2, MergeDirection.LEFT_TO_RIGHT, "any", LinkRoleDirection.DIRECT, null, "any", workItemsPairs, false, false);
+        DocumentsMergeContext context = new DocumentsMergeContext(polarionService, doc1, doc2, mergeParams.getMergeDirection(), mergeParams.getLinkRole(), mergeParams.getLinkRoleDirection(), diffModel, false)
+                .setAllowReferencedWorkItemMerge(mergeParams.isAllowedReferencedWorkItemMerge());
+
+        when(polarionService.getWorkItem("project1", "left", null)).thenReturn(leftWorkItem);
+        when(polarionService.getWorkItem("project2", "right", null)).thenReturn(rightWorkItem);
+
+        MergeWorkItemsPair pair = new MergeWorkItemsPair(leftWorkItem, rightWorkItem, List.of());
+
+        assertDoesNotThrow(() -> mergeService.updateAndMoveItem(pair, context));
+    }
+
+    @Test
     void testGetTestStepsData() {
         TestSteps testStepsMock = mock(TestSteps.class);
 


### PR DESCRIPTION
### Proposed changes

Get rid of duplicated field definitions in case of the same custom field on global and WorkItem type level.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
