### PR TITLE
fix(ui): do not render per-field merge ticker in documents-fields diff (WebKit click interception)

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -150,13 +150,17 @@ jobs:
       - name: 🌐 Install Playwright browser
         run: npx playwright install --with-deps ${{ matrix.browser }}
       - name: 🧪 Run Playwright E2E tests
-        run: npx playwright test --project=${{ matrix.browser }} --reporter=list
-      - name: 📤 Upload Playwright report
+        run: npx playwright test --project=${{ matrix.browser }} --reporter=list,html
+      - name: 📤 Upload Playwright report and traces
+        # test-results/ holds the per-test traces (trace: retain-on-failure) needed
+        # to diagnose failures; playwright-report/ is the browsable HTML report.
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: playwright-report-${{ matrix.browser }}
-          path: ui/playwright-report/
+          path: |
+            ui/playwright-report/
+            ui/test-results/
           retention-days: 3
           if-no-files-found: ignore
   # Deploy releases to Maven Central from main and LTS branches (release-v*)

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -133,6 +133,18 @@ jobs:
           node-version: 24.16.0
           cache: npm
           cache-dependency-path: ui/package-lock.json
+      - name: 🔢 Resolve Playwright version
+        id: playwright-version
+        run: echo "version=$(node -p "require('./package-lock.json').packages['node_modules/@playwright/test'].version")" >> "$GITHUB_OUTPUT"
+      - name: 💾 Cache Playwright browser binaries
+        # setup-node's `cache: npm` only caches the npm registry, not the browser
+        # binaries under ~/.cache/ms-playwright. Cache them keyed on the Playwright
+        # version so warm runs skip the ~100-200 MB per-browser download. System deps
+        # (apt) aren't cached, so `install --with-deps` below still runs every time.
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ matrix.browser }}-${{ steps.playwright-version.outputs.version }}
       - name: 📥 Install dependencies
         run: npm ci
       - name: 🌐 Install Playwright browser

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -71,7 +71,8 @@ jobs:
               SONAR_ARGS+=("-Dsonar.branch.name=${BRANCH_NAME}")
             fi
           fi
-          mvn --batch-mode -s "${SETTINGS_XML}" clean verify "${SONAR_ARGS[@]}"
+          # JS E2E (Playwright) tests run in the dedicated, per-browser sharded `e2e` job below
+          mvn --batch-mode -s "${SETTINGS_XML}" clean verify -DskipJsTests=true "${SONAR_ARGS[@]}"
       - name: 📦 Build with Maven for PRs
         if: github.event_name == 'pull_request'
         env:
@@ -85,7 +86,8 @@ jobs:
           if [ "${IS_PUBLIC}" = "true" ] && [ "${IS_TEMPLATE}" != "true" ]; then
             SONAR_ARGS+=(sonar:sonar "-Dsonar.pullrequest.base=${GITHUB_BASE_REF}" "-Dsonar.pullrequest.branch=${GITHUB_HEAD_REF}" "-Dsonar.pullrequest.key=${GITHUB_PR_NUMBER_REF}" "-Dsonar.exclusions=.github/**")
           fi
-          mvn --batch-mode -s "${SETTINGS_XML}" clean verify "${SONAR_ARGS[@]}"
+          # JS E2E (Playwright) tests run in the dedicated, per-browser sharded `e2e` job below
+          mvn --batch-mode -s "${SETTINGS_XML}" clean verify -DskipJsTests=true "${SONAR_ARGS[@]}"
       - name: 📋 Analyze dependencies
         run: mvn --batch-mode -s "${SETTINGS_XML}" dependency:analyze
         continue-on-error: false
@@ -99,10 +101,56 @@ jobs:
             target/*.pom
           retention-days: 1
           if-no-files-found: error
+  # Playwright E2E tests, sharded one browser per job.
+  #
+  # Each matrix leg runs on its own runner and starts its own `npm run dev` server
+  # (via playwright.config.js `webServer`), so the browsers no longer compete for a
+  # single dev server's CPU. That contention - 2 workers x 3 browsers against one
+  # server - was the root cause of the load-induced WebKit flakiness (the merge pane
+  # never reaching diffsLoadingProgress === 100 within the timeout). fail-fast is off
+  # so one browser's failure still lets the others report.
+  e2e:
+    name: E2E (${{ matrix.browser }})
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        browser: [chromium, firefox, webkit]
+    defaults:
+      run:
+        working-directory: ui
+    steps:
+      - name: 📄 Checkout the repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+      - name: 🧱 Set up Node.js
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903  # v6.0.0
+        with:
+          node-version: 24.16.0
+          cache: npm
+          cache-dependency-path: ui/package-lock.json
+      - name: 📥 Install dependencies
+        run: npm ci
+      - name: 🌐 Install Playwright browser
+        run: npx playwright install --with-deps ${{ matrix.browser }}
+      - name: 🧪 Run Playwright E2E tests
+        run: npx playwright test --project=${{ matrix.browser }} --reporter=list
+      - name: 📤 Upload Playwright report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: playwright-report-${{ matrix.browser }}
+          path: ui/playwright-report/
+          retention-days: 3
+          if-no-files-found: ignore
   # Deploy releases to Maven Central from main and LTS branches (release-v*)
   # See RELEASE.md for LTS branch documentation
   deploy-maven-central:
-    needs: build
+    needs: [build, e2e]
     if: ${{ needs.build.outputs.is_release == 'true' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release-v')) }}
     runs-on: ubuntu-latest
     permissions:
@@ -142,7 +190,7 @@ jobs:
   # Deploy to GitHub Packages (snapshots from main only) and upload release assets to GitHub Release
   # LTS branches (release-v*) only upload release assets, no snapshot deployment
   deploy-github-packages:
-    needs: build
+    needs: [build, e2e]
     if: ${{ github.ref == 'refs/heads/main' || (needs.build.outputs.is_release == 'true' && startsWith(github.ref, 'refs/heads/release-v')) }}
     runs-on: ubuntu-latest
     permissions:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,7 +195,7 @@ When merging rich text fields containing work item links:
 
 - Unit tests use mocked Polarion services (ITrackerService, IProjectService, etc.)
 - Integration tests require Polarion dependencies extracted via [polarion-artifacts-deployer](https://github.com/SchweizerischeBundesbahnen/polarion-artifacts-deployer)
-- Frontend uses Playwright for E2E testing (browsers auto-installed during build)
+- Frontend uses Playwright for E2E testing
 
 ### Deployment and Installation
 

--- a/ui/playwright.config.js
+++ b/ui/playwright.config.js
@@ -18,8 +18,10 @@ export default defineConfig({
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
-  /* Retry on CI only */
-  retries: process.env.CI ? 2 : 1,
+  /* DIAGNOSTIC (temporary): retries 0 + huge timeout to distinguish a slow
+     merge-pane (would pass given time) from a stuck one (real bug). Revert. */
+  retries: process.env.CI ? 0 : 1,
+  timeout: process.env.CI ? 120_000 : 30_000,
   /* On CI each browser runs in its own sharded job (one browser per runner, its
      own dev server - see the `e2e` job in maven-build.yml), so parallelism comes
      from the shards. Run a single worker within each shard so tests don't compete

--- a/ui/playwright.config.js
+++ b/ui/playwright.config.js
@@ -18,10 +18,18 @@ export default defineConfig({
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
-  /* DIAGNOSTIC (temporary): retries 0 + huge timeout to distinguish a slow
-     merge-pane (would pass given time) from a stuck one (real bug). Revert. */
-  retries: process.env.CI ? 0 : 1,
-  timeout: process.env.CI ? 120_000 : 30_000,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 1,
+  /* CI runs the Next.js dev server, which compiles each route on first hit; the
+     first test to touch a heavy route can need well over the 30s default while it
+     compiles. Give CI headroom (diagnosed via traces: the merge pane does render,
+     just slowly). Local keeps the tighter default. */
+  timeout: process.env.CI ? 60_000 : 30_000,
+  /* Raise the assertion timeout on CI too so auto-waiting expects (e.g. the URL
+     change after a swap, which triggers a slow reload) tolerate dev-server latency. */
+  expect: {
+    timeout: process.env.CI ? 10_000 : 5_000,
+  },
   /* On CI each browser runs in its own sharded job (one browser per runner, its
      own dev server - see the `e2e` job in maven-build.yml), so parallelism comes
      from the shards. Run a single worker within each shard so tests don't compete

--- a/ui/playwright.config.js
+++ b/ui/playwright.config.js
@@ -32,8 +32,10 @@ export default defineConfig({
     /* Base URL to use in actions like `await page.goto('/')`. */
     baseURL: 'http://localhost:3000',
 
-    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-    trace: 'on-first-retry',
+    /* Collect a trace for every failing attempt on CI (not just retries) so the
+       failing run is always diagnosable; locally keep the lighter on-first-retry.
+       See https://playwright.dev/docs/trace-viewer */
+    trace: process.env.CI ? 'retain-on-failure' : 'on-first-retry',
   },
 
   /* Configure projects for major browsers */

--- a/ui/playwright.config.js
+++ b/ui/playwright.config.js
@@ -20,8 +20,11 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 1,
-  /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 2 : undefined,
+  /* On CI each browser runs in its own sharded job (one browser per runner, its
+     own dev server - see the `e2e` job in maven-build.yml), so parallelism comes
+     from the shards. Run a single worker within each shard so tests don't compete
+     for the dev server's CPU - that contention is what made WebKit flaky. */
+  workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: 'html',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */

--- a/ui/src/components/diff/FieldsDiff.js
+++ b/ui/src/components/diff/FieldsDiff.js
@@ -70,7 +70,7 @@ export default function FieldsDiff({workItemsPair, pairSelected, pairSelectionTr
 
   return (
       <div className={`container-fluid g-0 diff-wrapper ${selected ? "selected" : ""} ${display ? "d-block" : "d-none"}`} data-testid={fieldName}>
-        {context.state.individualFieldsSelection && <FieldMergeTicker selected={selected} changeSelectionCallback={changeSelected} />}
+        {workItemsPair && context.state.individualFieldsSelection && <FieldMergeTicker selected={selected} changeSelectionCallback={changeSelected} />}
         <div className={`diff-header ${issues && issues.length > 0 ? "diff-issues" : ""}`} ref={refs.setReference} {...getReferenceProps()} >
           {fieldName}
         </div>

--- a/ui/tests/documents-fields.spec.js
+++ b/ui/tests/documents-fields.spec.js
@@ -18,7 +18,7 @@ test.describe("diffing and merging of documents' fields", () => {
 
     const versionFieldDiff = page.getByTestId('version-field-diff');
 
-    await expect(versionFieldDiff.locator(".merge-ticker .form-check input[type='checkbox']")).toBeVisible();
+    await expect(versionFieldDiff.locator(".merge-ticker .form-check input[type='checkbox']").first()).toBeVisible();
 
     const header = versionFieldDiff.locator(".diff-header");
     await expect(header).toBeVisible();
@@ -57,7 +57,7 @@ test.describe("diffing and merging of documents' fields", () => {
 
     const docDocTypeFieldDiff = page.getByTestId('docRevision-field-diff');
 
-    await expect(docDocTypeFieldDiff.locator(".merge-ticker .form-check input[type='checkbox']")).toBeVisible();
+    await expect(docDocTypeFieldDiff.locator(".merge-ticker .form-check input[type='checkbox']").first()).toBeVisible();
 
     const header = docDocTypeFieldDiff.locator(".diff-header");
     await expect(header).toBeVisible();
@@ -86,7 +86,7 @@ test.describe("diffing and merging of documents' fields", () => {
 
     const docDocTypeFieldDiff = page.getByTestId('docLanguage-field-diff');
 
-    await expect(docDocTypeFieldDiff.locator(".merge-ticker .form-check input[type='checkbox']")).toBeVisible();
+    await expect(docDocTypeFieldDiff.locator(".merge-ticker .form-check input[type='checkbox']").first()).toBeVisible();
 
     const header = docDocTypeFieldDiff.locator(".diff-header");
     await expect(header).toBeVisible();
@@ -153,7 +153,7 @@ test.describe("diffing and merging of documents' fields", () => {
 
     await expect(page.getByTestId("merge-confirmation-modal")).toBeVisible({ visible: false });
 
-    const selectionCheckbox = page.getByTestId('version-field-diff').locator('.merge-ticker input[type="checkbox"]');
+    const selectionCheckbox = page.getByTestId('version-field-diff').locator('.merge-ticker input[type="checkbox"]').first();
     await selectionCheckbox.isVisible();
     await selectionCheckbox.click();
 
@@ -188,7 +188,7 @@ test.describe("diffing and merging of documents' fields", () => {
     await expect(page.getByTestId("merge-confirmation-modal")).toBeVisible({ visible: false });
     await expect(page.getByTestId("merge-result-modal")).toBeVisible({ visible: false });
 
-    const selectionCheckbox = page.getByTestId('version-field-diff').locator('.merge-ticker input[type="checkbox"]');
+    const selectionCheckbox = page.getByTestId('version-field-diff').locator('.merge-ticker input[type="checkbox"]').first();
     await selectionCheckbox.isVisible();
     await selectionCheckbox.click();
 
@@ -275,7 +275,7 @@ test.describe("diffing and merging of documents' fields", () => {
     await expect(page.getByTestId("merge-confirmation-modal")).toBeVisible({ visible: false });
     await expect(page.getByTestId("merge-result-modal")).toBeVisible({ visible: false });
 
-    const selectionCheckbox = page.getByTestId('docRevision-field-diff').locator('.merge-ticker input[type="checkbox"]');
+    const selectionCheckbox = page.getByTestId('docRevision-field-diff').locator('.merge-ticker input[type="checkbox"]').first();
     await selectionCheckbox.isVisible();
     await selectionCheckbox.click();
 
@@ -346,7 +346,7 @@ test.describe("diffing and merging of documents' fields", () => {
     await expect(page.getByTestId("merge-confirmation-modal")).toBeVisible({ visible: false });
     await expect(page.getByTestId("merge-result-modal")).toBeVisible({ visible: false });
 
-    const selectionCheckbox = page.getByTestId('docLanguage-field-diff').locator('.merge-ticker input[type="checkbox"]');
+    const selectionCheckbox = page.getByTestId('docLanguage-field-diff').locator('.merge-ticker input[type="checkbox"]').first();
     await selectionCheckbox.isVisible();
     await selectionCheckbox.click();
 


### PR DESCRIPTION
## Summary

This pull request resolves the long-standing intermittent WebKit E2E failures that motivated #487. The investigation identified two distinct problems, of which only one is a test-harness concern.

### 1. Application defect affecting Safari (the primary failure)

In the documents-fields diff, the per-field `FieldMergeTicker` checkbox was rendering and overlapping the row-level selection checkbox. As a result, clicks on the row-level checkbox were intercepted (`subtree intercepts pointer events`; the click was retried 216 times over 120 seconds before timing out).

`FieldMergeTicker` is gated on `context.state.individualFieldsSelection`, which is persisted and defaults to `true` (`useAppContext.js`). `DocumentsFieldsDiff` resets it to `false` on mount, but this reset is a side effect. When the field rows render before the reset has propagated — which occurs more frequently under WebKit's scheduling — the additional ticker renders and overlaps the row-level checkbox. This defect affects real Safari users, who may intermittently be unable to select fields for merging.

Resolution: `FieldMergeTicker` operates on `workItemsPair.fieldsToMerge` and is therefore not applicable in the documents-fields diff, which renders `FieldsDiff` without a `workItemsPair`. Gating the ticker on `workItemsPair` ensures it never renders in that view, independent of the timing of the flag reset. The work-item field diff (`DiffContent`) always provides a `workItemsPair`, so its behaviour is unchanged.

### 2. Development-server compilation latency (the "merge-pane hidden" timeouts)

A diagnostic run (`retries: 0` with a 120-second timeout and `retain-on-failure` traces) confirmed that the merge pane does render under CI, but more slowly than the 30-second default permits, because Next.js development mode compiles each route on first access. This is addressed by increasing the CI timeouts: per-test timeout from 30 to 60 seconds, and assertion timeout from 5 to 10 seconds. Local values are unchanged.

## CI changes (which also reduce contention and shorten the pipeline)

- Shard the E2E suite by browser: each browser runs in its own `e2e` matrix job with its own development server, eliminating competition for a single server's CPU. JavaScript tests are skipped in the Maven build (`-DskipJsTests=true`); the `deploy-*` jobs now declare `needs: [build, e2e]` to preserve the requirement that tests pass before release.
- Run a single worker per shard on CI; parallelism is provided by the shards.
- Cache the Playwright browser binaries per shard, keyed on the Playwright version.
- Capture traces on failure (`retain-on-failure` and upload of `test-results/`). This instrumentation enabled the root-cause diagnosis and is retained as a permanent aid.

## Verification

The WebKit shard passed five of five runs on the fix commit (two original runs and three reruns of the sharded `E2E (webkit)` job). The chromium and firefox shards passed throughout.

## Relationship to #487

This pull request incorporates the selector fix from #487 and additionally resolves the underlying defect that #487 did not identify. #487 has been closed as superseded.
