### PR TITLE
ci: skip JS tests in deploy jobs

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -197,6 +197,7 @@ jobs:
         run: |
           mvn --batch-mode -s "${SETTINGS_XML}" clean deploy \
             -Dmaven.test.skip=true \
+            -DskipJsTests=true \
             -P gpg-sign \
             -P central-publishing \
             -Dcentral.timeout=3600 \
@@ -241,6 +242,7 @@ jobs:
         run: |
           mvn --batch-mode -s "${SETTINGS_XML}" deploy \
             -Dmaven.test.skip=true \
+            -DskipJsTests=true \
             -Dmaven.javadoc.skip=true \
             -Dmaven.source.skip=true \
             -P deploy-github-packages


### PR DESCRIPTION
### Proposed changes

The deploy-github-packages and deploy-maven-central jobs re-ran the full Playwright E2E suite on every deploy, even though the dedicated e2e jobs (needs: [build, e2e]) already ran them across all browsers.

Cause: the frontend-maven-plugin npm-test goal (playwright:test:headless) is gated on ${skipJsTests}, which -Dmaven.test.skip=true does not affect. Since mvn deploy runs the lifecycle through the test phase, Playwright executed again. Pass -DskipJsTests=true (as the build job already does) to skip the redundant run; Java tests stay skipped via -Dmaven.test.skip.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
