### PR TITLE
fix: add disabled and keyboard-focus checkbox states

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>ch.sbb.polarion.extensions</groupId>
         <artifactId>ch.sbb.polarion.extension.generic</artifactId>
-        <version>15.3.0</version>
+        <version>15.3.1</version>
     </parent>
 
     <artifactId>ch.sbb.polarion.extension.diff-tool</artifactId>

--- a/src/main/resources/webapp/diff-tool-admin/pages/execution.jsp
+++ b/src/main/resources/webapp/diff-tool-admin/pages/execution.jsp
@@ -95,7 +95,7 @@
         }
 
         .more-info {
-            background: url(/polarion/ria/images/msginfo.png) no-repeat;
+            background: var(--sbb-info-icon) no-repeat;
             display: inline-block;
             width: 17px;
             height: 17px;

--- a/src/main/resources/webapp/diff-tool/css/common.css
+++ b/src/main/resources/webapp/diff-tool/css/common.css
@@ -108,24 +108,10 @@ a, td, div, li, ul, input, button {
     margin: 10px 0;
 }
 
-.buttons-wrapper button {
-    background-color: transparent;
-    border: 1px solid #DEDEDE;
-    color: #555;
-    padding: 4px 8px;
-    font-size: 12px;
-    font-weight: bold;
-    cursor: pointer;
-}
-
+/* Button chrome (transparent action button) comes from the shared system (generic buttons.css
+   aliases `.buttons-wrapper button`). Only the wrapper layout / icon / disabled bits stay local. */
 .buttons-wrapper button:not(:first-child) {
     margin-left: 5px;
-}
-
-.buttons-wrapper button:disabled {
-    text-shadow: white 1px 1px 0.01em;
-    color: #C9D1D7;
-    cursor: default;
 }
 
 .buttons-wrapper .divider {
@@ -138,10 +124,6 @@ a, td, div, li, ul, input, button {
 .buttons-wrapper button img {
     margin-right: 6px;
     vertical-align: bottom;
-}
-
-.buttons-wrapper button:disabled img {
-    opacity: 0.3;
 }
 
 .alert {
@@ -225,7 +207,7 @@ a, td, div, li, ul, input, button {
     appearance: none !important;
     -webkit-appearance: none !important;
     -moz-appearance: none !important;
-    background: transparent url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAYAAAAGCAYAAADgzO9IAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAOUlEQVR4nGNgwAOKGRgY/qNhkBgDCwMDw0UkwasMDAysMF22DAwM/6ASjuhGLmVgYFiCzS5JKAYDACJtDIY1VpdwAAAAAElFTkSuQmCC) no-repeat;
+    background: transparent var(--sbb-combo-chevron) no-repeat;
     background-position: calc(100% - 1rem) 55% !important;
     padding: 5px 2rem 5px 10px;
 }

--- a/src/main/resources/webapp/diff-tool/html/copy-tool.html
+++ b/src/main/resources/webapp/diff-tool/html/copy-tool.html
@@ -2,6 +2,7 @@
 <link href='/polarion/diff-tool/ui/generic/css/control-tokens.css' rel='stylesheet'>
 <link href='/polarion/diff-tool/ui/generic/css/radios.css' rel='stylesheet'>
 <link href='/polarion/diff-tool/ui/generic/css/inputs.css' rel='stylesheet'>
+<link href='/polarion/diff-tool/ui/generic/css/buttons.css' rel='stylesheet'>
 <link href='/polarion/diff-tool/ui/generic/css/searchable-dropdown.css' rel='stylesheet'
       onload='import("/polarion/diff-tool/ui/js/modules/CopyTool.js")
                 .then(module => new module.default({SOURCE_DOC_PARAMS}))
@@ -54,7 +55,7 @@
 
     <div class='buttons-wrapper'>
         <button type='button' id="create-document" disabled>
-            <img src='/polarion/ria/images/control/tablePlus.png' alt=""/>Create Document
+            <span class="sbb-icon-table-plus" role="img" aria-label="Add" style="margin-right:6px"></span>Create Document
         </button>
     </div>
     <div id='creation-success' class="alert">

--- a/src/main/resources/webapp/diff-tool/html/diff-tool.html
+++ b/src/main/resources/webapp/diff-tool/html/diff-tool.html
@@ -2,6 +2,7 @@
 <link href='/polarion/diff-tool/ui/generic/css/control-tokens.css' rel='stylesheet'>
 <link href='/polarion/diff-tool/ui/generic/css/radios.css' rel='stylesheet'>
 <link href='/polarion/diff-tool/ui/generic/css/inputs.css' rel='stylesheet'>
+<link href='/polarion/diff-tool/ui/generic/css/buttons.css' rel='stylesheet'>
 <link href='/polarion/diff-tool/ui/generic/css/searchable-dropdown.css' rel='stylesheet'
       onload='import("/polarion/diff-tool/ui/js/modules/DiffTool.js")
                 .then(module => new module.default({SOURCE_DOC_PARAMS}))

--- a/src/main/resources/webapp/diff-tool/js/modules/DiffTool.js
+++ b/src/main/resources/webapp/diff-tool/js/modules/DiffTool.js
@@ -1,5 +1,6 @@
 import ExtensionContext from "../../generic/js/modules/ExtensionContext.js";
 import SearchableDropdown from "../../generic/js/modules/SearchableDropdown.js";
+import { initNumericSpinners } from "../../generic/js/modules/NumericSpinner.js";
 import GenericMixin from "./GenericMixin.js";
 
 export default class DiffTool extends GenericMixin {
@@ -76,6 +77,9 @@ export default class DiffTool extends GenericMixin {
       allowEmpty: true
     });
     this.configDropdown.restoreSelection();
+
+    // Replace the native number spinner (revision input) with the 2606 caret spinner.
+    initNumericSpinners(document);
   }
 
   projectChanged() {

--- a/ui/src/app/globals.css
+++ b/ui/src/app/globals.css
@@ -322,6 +322,13 @@ a:hover {
   background-image: var(--sbb-checkbox-checked, url('/polarion/ria/images/checkbox/checked.png'));
 }
 
+/* Indeterminate (partial select-all): Polarion ships no such image, generic hosts it. Reference it
+   absolutely — the --sbb-checkbox-indeterminate token is a path relative to control-tokens.css that
+   resolves against this bundled stylesheet and 404s, and Next.js would try to bundle a relative url(). */
+.app .form-check-input:indeterminate {
+  background-image: url('/polarion/diff-tool-app/ui/generic/images/checkbox-indeterminate.png');
+}
+
 .app .form-check-input:focus {
   border-color: transparent;
   box-shadow: none;
@@ -346,6 +353,10 @@ a:hover {
 
 .app .form-check-input:focus-visible:checked {
   background-image: var(--sbb-checkbox-checked-focus, url('/polarion/ria/images/checkbox/checked_focus.png'));
+}
+
+.app .form-check-input:focus-visible:indeterminate {
+  background-image: url('/polarion/diff-tool-app/ui/generic/images/checkbox-indeterminate-focus.png');
 }
 
 .control-pane .export-controls {

--- a/ui/src/app/globals.css
+++ b/ui/src/app/globals.css
@@ -221,25 +221,9 @@ a:hover {
   }
 }
 
-.link-role-direction-select {
-  display: inline-block;
-  width: auto;
-  font-size: 1em;
-  padding: 0.2rem 2rem 0.2rem 0.5rem;
-  height: auto;
-  line-height: 1.4;
-  border: 1px solid #adb5bd;
-  border-radius: 4px;
-  color: #495057;
-  background-color: #fff;
-  cursor: pointer;
-}
-
-.link-role-direction-select:focus {
-  border-color: var(--polarion-blue);
-  box-shadow: 0 0 0 2px rgba(0, 121, 147, 0.15);
-  outline: none;
-}
+/* The link-role picker renders as the shared SearchableDropdown (see MergePane), which brings its
+   own combobox styling from searchable-dropdown.css — no native-<select> border/focus rules here,
+   which used to stack on top of the SD and left a stray dark frame after selection. */
 
 .sticky-top {
   transition: all .1s linear;
@@ -310,23 +294,25 @@ a:hover {
 .app .form-check-input {
   appearance: none;
   -webkit-appearance: none;
-  width: var(--sbb-toggle-size, 15px);
-  height: var(--sbb-toggle-size, 15px);
+  width: var(--sbb-toggle-size);
+  height: var(--sbb-toggle-size);
   border: none;
   border-radius: 0;
-  background: var(--sbb-checkbox-unchecked, url('/polarion/ria/images/checkbox/unchecked.png')) no-repeat center;
-  background-size: var(--sbb-toggle-size, 15px) var(--sbb-toggle-size, 15px);
+  background: var(--sbb-checkbox-unchecked) no-repeat center;
+  background-size: var(--sbb-toggle-size) var(--sbb-toggle-size);
 }
 
 .app .form-check-input:checked {
-  background-image: var(--sbb-checkbox-checked, url('/polarion/ria/images/checkbox/checked.png'));
+  background-image: var(--sbb-checkbox-checked);
 }
 
-/* Indeterminate (partial select-all): Polarion ships no such image, generic hosts it. Reference it
-   absolutely — the --sbb-checkbox-indeterminate token is a path relative to control-tokens.css that
-   resolves against this bundled stylesheet and 404s, and Next.js would try to bundle a relative url(). */
+/* Indeterminate (partial select-all): the --sbb-checkbox-indeterminate token is a self-contained
+   data-URI (inlined from images/checkbox/indeterminate.svg at build, issue #528), so it resolves in
+   this bundled stylesheet without a 404. Use the full background shorthand so it also resets
+   Bootstrap's solid-blue :indeterminate background-color. */
 .app .form-check-input:indeterminate {
-  background-image: url('/polarion/diff-tool-app/ui/generic/images/checkbox-indeterminate.png');
+  background: var(--sbb-checkbox-indeterminate) no-repeat center;
+  background-size: var(--sbb-toggle-size) var(--sbb-toggle-size);
 }
 
 .app .form-check-input:focus {
@@ -338,21 +324,21 @@ a:hover {
 /* Disabled: Polarion's greyed read-only images so a non-selectable checkbox reads as disabled. */
 .app .form-check-input:disabled {
   cursor: default;
-  background-image: var(--sbb-checkbox-unchecked-readonly, url('/polarion/ria/images/checkbox/unchecked_readonly.png'));
+  background-image: var(--sbb-checkbox-unchecked-readonly);
 }
 
 .app .form-check-input:disabled:checked {
-  background-image: var(--sbb-checkbox-checked-readonly, url('/polarion/ria/images/checkbox/checked_readonly.png'));
+  background-image: var(--sbb-checkbox-checked-readonly);
 }
 
 /* Keyboard focus: show Polarion's focus-ring image on keyboard navigation (the :focus rule above
    already strips Bootstrap's own ring). */
 .app .form-check-input:focus-visible {
-  background-image: var(--sbb-checkbox-unchecked-focus, url('/polarion/ria/images/checkbox/unchecked_focus.png'));
+  background-image: var(--sbb-checkbox-unchecked-focus);
 }
 
 .app .form-check-input:focus-visible:checked {
-  background-image: var(--sbb-checkbox-checked-focus, url('/polarion/ria/images/checkbox/checked_focus.png'));
+  background-image: var(--sbb-checkbox-checked-focus);
 }
 
 .app .form-check-input:focus-visible:indeterminate {
@@ -384,16 +370,16 @@ a:hover {
   /* Polarion 2606 combobox look via generic tokens (overrides Bootstrap's chevron/blue focus). */
   appearance: none;
   -webkit-appearance: none;
-  border: 1px solid var(--sbb-control-border, #c9c9c9);
-  border-radius: var(--sbb-control-radius, 0);
-  background-image: var(--sbb-combo-chevron, url('/polarion/ria/images/combo_box_old.png'));
+  border: 1px solid var(--sbb-control-border);
+  border-radius: var(--sbb-control-radius);
+  background-image: var(--sbb-combo-chevron);
   background-repeat: no-repeat;
   background-position: right 0.6rem center;
   background-size: 16px 16px;
 }
 
 .control-pane .select-set .form-select:focus {
-  border-color: var(--sbb-control-border-focus, #1491eb);
+  border-color: var(--sbb-control-border-focus);
   box-shadow: none;
   outline: none;
 }
@@ -576,7 +562,7 @@ a.wi-badge:hover {
 .loader {
   width: 50px;
   aspect-ratio: 1;
-  background: var(--sbb-spinner, url("/polarion/ria/images/progressWheel48.svg")) center / contain no-repeat;
+  background: var(--sbb-spinner) center / contain no-repeat;
 }
 
 .wi-loader {

--- a/ui/src/app/globals.css
+++ b/ui/src/app/globals.css
@@ -328,6 +328,26 @@ a:hover {
   outline: none;
 }
 
+/* Disabled: Polarion's greyed read-only images so a non-selectable checkbox reads as disabled. */
+.app .form-check-input:disabled {
+  cursor: default;
+  background-image: var(--sbb-checkbox-unchecked-readonly, url('/polarion/ria/images/checkbox/unchecked_readonly.png'));
+}
+
+.app .form-check-input:disabled:checked {
+  background-image: var(--sbb-checkbox-checked-readonly, url('/polarion/ria/images/checkbox/checked_readonly.png'));
+}
+
+/* Keyboard focus: show Polarion's focus-ring image on keyboard navigation (the :focus rule above
+   already strips Bootstrap's own ring). */
+.app .form-check-input:focus-visible {
+  background-image: var(--sbb-checkbox-unchecked-focus, url('/polarion/ria/images/checkbox/unchecked_focus.png'));
+}
+
+.app .form-check-input:focus-visible:checked {
+  background-image: var(--sbb-checkbox-checked-focus, url('/polarion/ria/images/checkbox/checked_focus.png'));
+}
+
 .control-pane .export-controls {
   margin-top: 1em;
   border-top: thin solid grey;

--- a/ui/src/app/layout.js
+++ b/ui/src/app/layout.js
@@ -20,7 +20,11 @@ export default function RootLayout({ children }) {
         <link rel="stylesheet" href="/polarion/diff-tool-app/ui/generic/css/searchable-dropdown.css" />
       </head>
       <Body>
-        <main className="app">
+        {/* .sbb-ui scopes generic's --sbb-* design tokens to this app's subtree (issue #515):
+            the SPA reads tokens from its own bundled generic instead of whichever extension's
+            :root loaded last on a shared surface, and it keeps resolving once generic drops the
+            :root fallback. */}
+        <main className="app sbb-ui">
           <Suspense fallback={<Loading/>}>
             {children}
           </Suspense>

--- a/ui/src/components/merge/MergePane.js
+++ b/ui/src/components/merge/MergePane.js
@@ -1,5 +1,6 @@
 import {faArrowRightLong} from "@fortawesome/free-solid-svg-icons";
 import MergeButton from "@/components/merge/MergeButton";
+import SearchableSelect from "@/components/SearchableSelect";
 import {useContext, useEffect, useState} from "react";
 import Modal from "@/components/Modal";
 import AppContext from "@/components/AppContext";
@@ -89,11 +90,11 @@ export default function MergePane({leftContext, rightContext, diff_type, merging
             {rightContext && !rightContext.authorizedForMerge && <span>You are not authorized to merge into target project</span>}
             {!mergeDisabled && (diff_type === DiffTypes.DOCUMENTS_DIFF || diff_type === DiffTypes.WORK_ITEMS_DIFF) && <label className="link-role-direction-label">
               <span className="link-role-direction-text">Link role direction for created WorkItems:</span>
-              <select className="form-select link-role-direction-select" value={linkRoleDirection}
-                      onChange={(e) => setLinkRoleDirection(e.target.value)} title="Link role direction for created WorkItems">
+              <SearchableSelect className="form-select" value={linkRoleDirection}
+                                onChange={(e) => setLinkRoleDirection(e.target.value)} searchable={false}>
                 <option value={LINK_ROLE_DIRECTION_DIRECT}>Direct</option>
                 <option value={LINK_ROLE_DIRECTION_REVERSE}>Reverse</option>
-              </select>
+              </SearchableSelect>
             </label>}
             <MergeButton fontAwesomeIcon={faArrowRightLong} clickHandler={() => confirmMerge(LEFT_TO_RIGHT)}
                          style={{justifyContent: "right"}} disabled={mergeDisabled || mergingContext.selectionCount === 0} />

--- a/ui/src/components/merge/MergePane.js
+++ b/ui/src/components/merge/MergePane.js
@@ -77,7 +77,9 @@ export default function MergePane({leftContext, rightContext, diff_type, merging
               <label className="select-all" style={{
                 display: selectAllVisible ? "inline-block" : "none"
               }}>
-                <input className="form-check-input" type="checkbox" checked={mergingContext.selectAll} onChange={() => {
+                <input className="form-check-input" type="checkbox"
+                       ref={(el) => { if (el) { el.indeterminate = mergingContext.selectionCount > 0 && !mergingContext.selectAll; } }}
+                       checked={mergingContext.selectAll} onChange={() => {
                   mergingContext.setAndApplySelectAll(!mergingContext.selectAll);
                 }}/>
                 select all

--- a/ui/tests/documents.spec.js
+++ b/ui/tests/documents.spec.js
@@ -224,9 +224,11 @@ test.describe("page of diffing documents' WorkItems", () => {
       }
     }
 
-    // When single checkbox is un-ticked check that "select all" is also automatically un-ticked
+    // When single checkbox is un-ticked check that "select all" is also automatically un-ticked;
+    // with other items still selected it shows the indeterminate (partial) state, otherwise plain unchecked.
     await mergeTickers.nth(0).click();
     await expect(selectAllCheckbox).toBeChecked({ checked: false });
+    await expect(selectAllCheckbox).toHaveJSProperty('indeterminate', mergeTickersCount > 1);
   });
 
   test('select single', async ({ page }) => {


### PR DESCRIPTION
### Proposed changes

This pull request enhances the checkbox UI in the merge pane to support and visually indicate the indeterminate (partial select-all) state, improves accessibility with better focus and disabled styles, and updates tests to verify the new behavior.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
