### PR TITLE
fix: replace native multi-select listboxes on Diff Configuration with multiselect chip comboboxes

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -2596,6 +2596,10 @@
       "WorkItemStatus": {
         "description": "WorkItem status data",
         "properties": {
+          "iconUrl": {
+            "description": "URL of the status icon, if defined",
+            "type": "string"
+          },
           "id": {
             "description": "Status ID",
             "type": "string"

--- a/src/main/java/ch/sbb/polarion/extension/diff_tool/rest/model/diff/WorkItemStatus.java
+++ b/src/main/java/ch/sbb/polarion/extension/diff_tool/rest/model/diff/WorkItemStatus.java
@@ -23,4 +23,7 @@ public class WorkItemStatus {
 
     @Schema(description = "WorkItem type name")
     private String wiTypeName;
+
+    @Schema(description = "URL of the status icon, if defined")
+    private String iconUrl;
 }

--- a/src/main/java/ch/sbb/polarion/extension/diff_tool/service/PolarionService.java
+++ b/src/main/java/ch/sbb/polarion/extension/diff_tool/service/PolarionService.java
@@ -16,6 +16,7 @@ import ch.sbb.polarion.extension.diff_tool.util.RequestContextUtil;
 import ch.sbb.polarion.extension.generic.settings.NamedSettings;
 import ch.sbb.polarion.extension.generic.settings.NamedSettingsRegistry;
 import ch.sbb.polarion.extension.generic.settings.SettingId;
+import ch.sbb.polarion.extension.generic.util.EnumUtils;
 import ch.sbb.polarion.extension.generic.util.ScopeUtils;
 import com.polarion.alm.projects.IProjectService;
 import com.polarion.alm.projects.model.IFolder;
@@ -284,6 +285,7 @@ public class PolarionService extends ch.sbb.polarion.extension.generic.service.P
                 .name(statusOpt.getName())
                 .wiTypeId(wiTypeOpt != null ? wiTypeOpt.getId() : null)
                 .wiTypeName(wiTypeOpt != null ? wiTypeOpt.getName() : null)
+                .iconUrl(EnumUtils.getIconUrl(statusOpt))
                 .build();
     }
 

--- a/src/main/resources/webapp/diff-tool-admin/js/modules/diff.js
+++ b/src/main/resources/webapp/diff-tool-admin/js/modules/diff.js
@@ -1,5 +1,6 @@
 import ExtensionContext from '../../ui/generic/js/modules/ExtensionContext.js';
 import ConfigurationsPane from '../../ui/generic/js/modules/ConfigurationsPane.js';
+import SearchableDropdown from '../../ui/generic/js/modules/SearchableDropdown.js';
 
 const ctx = new ExtensionContext({
   extension: 'diff-tool',
@@ -22,13 +23,12 @@ ctx.onClick(
 const Fields = {
   fields: [],
   availableFields: ctx.getElementById("available-fields"),
+  availableFieldsFilter: ctx.getElementById("available-fields-filter"),
   selectedFields: ctx.getElementById("selected-fields"),
   addButton: ctx.getElementById("add-button"),
   removeButton: ctx.getElementById("remove-button"),
   hyperlinkSettingsContainer: ctx.getElementById("hyperlink-settings-container"),
-  hyperlinkRolesSearchInput: ctx.getElementById("search-hyperlink-roles-input"),
   linkedWorkitemSettingsContainer: ctx.getElementById("linked-workitem-settings-container"),
-  linkedWorkitemRolesSearchInput: ctx.getElementById("search-linked-workitem-roles-input"),
 
   init: function () {
     ctx.getElementById("fields-load-error").style.display = "none";
@@ -37,68 +37,7 @@ const Fields = {
     this.selectedFields.addEventListener("change", (event) => this.removeButton.disabled = event.target.selectedIndex === -1);
     this.addButton.addEventListener("click", () => this.addFieldClicked());
     this.removeButton.addEventListener("click", () => this.removeFieldClicked());
-
-    this.hyperlinkRolesSearchInput.addEventListener('input', function() {
-      const searchTerm = this.value.toLowerCase().trim();
-      const options = HyperlinkRoles.roles.options;
-
-      // Store currently selected values
-      const selectedValues = Array.from(HyperlinkRoles.roles.selectedOptions)
-          .map(option => option.value);
-
-      const searchParts = searchTerm.split(/\s+/).filter(part => part.length > 0);
-
-      // Filter options
-      for (let i = 0; i < options.length; i++) {
-        const option = options[i];
-        const isMatch = searchParts.length === 0 ||
-            searchParts.every(part =>
-                option.text.toLowerCase().includes(part)
-            );
-
-        // Toggle visibility based on search match
-        option.hidden = !isMatch;
-      }
-
-      // Re-select previously selected options
-      selectedValues.forEach(value => {
-        const option = HyperlinkRoles.roles.querySelector(`option[value="${value}"]`);
-        if (option) {
-          option.selected = true;
-        }
-      });
-    });
-
-    this.linkedWorkitemRolesSearchInput.addEventListener('input', function() {
-      const searchTerm = this.value.toLowerCase().trim();
-      const options = LinkedWorkItemRoles.roles.options;
-
-      // Store currently selected values
-      const selectedValues = Array.from(LinkedWorkItemRoles.roles.selectedOptions)
-          .map(option => option.value);
-
-      const searchParts = searchTerm.split(/\s+/).filter(part => part.length > 0);
-
-      // Filter options
-      for (let i = 0; i < options.length; i++) {
-        const option = options[i];
-        const isMatch = searchParts.length === 0 ||
-            searchParts.every(part =>
-                option.text.toLowerCase().includes(part)
-            );
-
-        // Toggle visibility based on search match
-        option.hidden = !isMatch;
-      }
-
-      // Re-select previously selected options
-      selectedValues.forEach(value => {
-        const option = LinkedWorkItemRoles.roles.querySelector(`option[value="${value}"]`);
-        if (option) {
-          option.selected = true;
-        }
-      });
-    });
+    this.availableFieldsFilter.addEventListener("input", () => this.applyAvailableFieldsFilter());
 
     return new Promise((resolve, reject) => {
       ctx.callAsync({
@@ -132,8 +71,25 @@ const Fields = {
     for (const field of selectedFields) {
       this.addOption(this.selectedFields, field.key, field.wiTypeId);
     }
+    this.applyAvailableFieldsFilter();
     this.checkHyperlinkSettingsVisibility();
     this.checkLinkedWorkitemSettingsVisibility();
+  },
+
+  // Hide options in the "Available fields" list whose label doesn't match every whitespace-separated
+  // part of the filter term. Re-applied whenever the list is rebuilt so the filter survives moves.
+  applyAvailableFieldsFilter: function () {
+    const searchParts = this.availableFieldsFilter.value.toLowerCase().trim().split(/\s+/).filter(part => part.length > 0);
+    for (const option of this.availableFields.options) {
+      const hidden = searchParts.length > 0 && !searchParts.every(part => option.text.toLowerCase().includes(part));
+      option.hidden = hidden;
+      // Deselect options the filter hides so they can't be moved while invisible.
+      if (hidden) {
+        option.selected = false;
+      }
+    }
+    // Setting option.selected programmatically doesn't fire 'change', so refresh the Add button state.
+    this.addButton.disabled = this.availableFields.selectedIndex === -1;
   },
 
   addFieldClicked: function () {
@@ -165,7 +121,9 @@ const Fields = {
     for (const field of newFieldsSorted) {
       this.addOption(toSelect, field.key, field.wiTypeId);
     }
+    this.applyAvailableFieldsFilter();
     this.checkHyperlinkSettingsVisibility();
+    this.checkLinkedWorkitemSettingsVisibility();
   },
 
   addOption: function (select, fieldKey, wiTypeId) {
@@ -209,6 +167,7 @@ const Fields = {
 
 const Statuses = {
   statusesToIgnore: ctx.getElementById("statuses-to-ignore"),
+  dropdown: null,
 
   load: function () {
     ctx.getElementById("statuses-load-error").style.display = "none";
@@ -222,9 +181,19 @@ const Statuses = {
           for (let status of JSON.parse(responseText)) {
             const opt = document.createElement('option');
             opt.value = status.id;
+            if (status.iconUrl) {
+              opt.setAttribute('data-icon', status.iconUrl);
+            }
             opt.innerHTML = status.wiTypeName ? `${status.name} [${status.id} - ${status.wiTypeName}]` : `${status.name} [${status.id}]`;
             this.statusesToIgnore.appendChild(opt);
           }
+          // Upgrade to the shared Polarion-styled multiselect (chips + built-in search). Instantiated
+          // after the options are populated so it reflects the loaded list.
+          this.dropdown = new SearchableDropdown({
+            element: this.statusesToIgnore,
+            multiselect: true,
+            placeholder: 'Select statuses to ignore...'
+          });
           resolve();
         },
         onError: () => {
@@ -239,6 +208,7 @@ const Statuses = {
 
 const HyperlinkRoles = {
   roles: ctx.getElementById("hyperlink-roles"),
+  dropdown: null,
 
   load: function () {
     ctx.getElementById("hyperlink-roles-load-error").style.display = "none";
@@ -255,6 +225,11 @@ const HyperlinkRoles = {
             opt.innerHTML = `[${role.workItemTypeName}] ${role.name}`;
             this.roles.appendChild(opt);
           }
+          this.dropdown = new SearchableDropdown({
+            element: this.roles,
+            multiselect: true,
+            placeholder: 'Select hyperlink roles...'
+          });
           resolve();
         },
         onError: () => {
@@ -268,6 +243,7 @@ const HyperlinkRoles = {
 
 const LinkedWorkItemRoles = {
   roles: ctx.getElementById("linked-workitem-roles"),
+  dropdown: null,
 
   load: function () {
     ctx.getElementById("linked-workitem-roles-load-error").style.display = "none";
@@ -284,6 +260,11 @@ const LinkedWorkItemRoles = {
             opt.innerHTML = `${role.name}`;
             this.roles.appendChild(opt);
           }
+          this.dropdown = new SearchableDropdown({
+            element: this.roles,
+            multiselect: true,
+            placeholder: 'Select linked WorkItem roles...'
+          });
           resolve();
         },
         onError: () => {
@@ -335,6 +316,17 @@ function setConfiguration(text) {
   Array.from(Statuses.statusesToIgnore.options).forEach(option => option.selected = diffModel.statusesToIgnore.includes(option.value));
   Array.from(HyperlinkRoles.roles.options).forEach(option => option.selected = diffModel.hyperlinkRoles.includes(option.value));
   Array.from(LinkedWorkItemRoles.roles.options).forEach(option => option.selected = diffModel.linkedWorkItemRoles.includes(option.value));
+  // Reflect the loaded selection in the wrapping dropdowns (setting option.selected above does not
+  // dispatch a change event, so the chips must be synced explicitly).
+  if (Statuses.dropdown) {
+    Statuses.dropdown.syncFromElement();
+  }
+  if (HyperlinkRoles.dropdown) {
+    HyperlinkRoles.dropdown.syncFromElement();
+  }
+  if (LinkedWorkItemRoles.dropdown) {
+    LinkedWorkItemRoles.dropdown.syncFromElement();
+  }
   if (diffModel.bundleTimestamp !== ctx.getValueById('bundle-timestamp')) {
     loadDefaultContent()
         .then((responseText) => {

--- a/src/main/resources/webapp/diff-tool-admin/pages/configuration.jsp
+++ b/src/main/resources/webapp/diff-tool-admin/pages/configuration.jsp
@@ -24,13 +24,19 @@
             flex: 1;
             display: flex;
             flex-direction: column;
+            --select-column-width: 440px;
+            --buttons-column-width: 100px;
+            --flex-gap: 20px;
+            /* Full width of the top two-pane component: both select columns + the button column between
+               them + the two gaps. The bottom dropdowns are sized to match this. */
+            --top-component-width: calc(2 * var(--select-column-width) + var(--buttons-column-width) + 2 * var(--flex-gap));
         }
         .diff-fields-error {
             color: red;
         }
         .flex-container {
             display: flex;
-            column-gap: 20px;
+            column-gap: var(--flex-gap);
             flex-direction: row;
         }
         .column {
@@ -39,15 +45,24 @@
             row-gap: 5px;
         }
         .select-column {
-            width: 440px;
+            width: var(--select-column-width);
             min-height: 200px;
         }
         .select-column select {
             height: 100%;
         }
         .buttons-column {
-            width: 100px;
+            width: var(--buttons-column-width);
             justify-content: center;
+        }
+        /* The three bottom dropdowns are stacked vertically, each spanning the full width of the top
+           two-pane component. */
+        .bottom-settings {
+            flex-direction: column;
+            row-gap: var(--flex-gap);
+        }
+        .bottom-select-column {
+            width: var(--top-component-width);
         }
         .toolbar-button {
             text-align: center;
@@ -59,6 +74,83 @@
         .checkbox.input-group label {
             width: auto;
         }
+        /* The bottom dropdowns are upgraded to the shared SearchableDropdown; let each wrapper fill
+           its column (the component only copies an explicit width from the original element). */
+        .bottom-select-column .searchable-dropdown {
+            width: 100%;
+        }
+        /* "Available fields:" label and its filter input share one row above the list. */
+        .available-fields-header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 10px;
+        }
+        .filter-input {
+            flex: 1;
+            min-width: 0;
+            box-sizing: border-box;
+            /* Filter icon pinned to the left, sized so it can't crowd the text. */
+            background: var(--sbb-control-bg) url("/polarion/ria/images/filter.png") no-repeat 6px center;
+            background-size: 14px 14px;
+            padding-left: 26px !important;
+            border: 1px solid var(--sbb-control-border);
+            border-radius: var(--sbb-control-radius);
+            color: var(--sbb-control-text);
+            font-family: var(--sbb-control-font-family);
+            font-size: var(--sbb-control-font-size);
+            font-weight: var(--sbb-control-font-weight);
+            outline: none;
+        }
+        .filter-input:focus {
+            border-color: var(--sbb-control-border-focus);
+        }
+        /* The top "transfer list" keeps its two-pane layout and fixed height, but is restyled to read
+           as part of the same design system as the shared controls, reusing the --sbb-* tokens
+           (scoped via .standard-admin-page). */
+        #available-fields,
+        #selected-fields {
+            border: 1px solid var(--sbb-control-border);
+            border-radius: var(--sbb-control-radius);
+            background-color: var(--sbb-control-bg);
+            color: var(--sbb-control-text);
+            font-family: var(--sbb-control-font-family);
+            font-size: var(--sbb-control-font-size);
+            font-weight: var(--sbb-control-font-weight);
+            padding: 2px;
+            outline: none;
+            /* Match the soft elevation the generic controls animate on hover/focus. */
+            transition: box-shadow 0.15s ease, border-color 0.15s ease;
+        }
+        #available-fields:hover,
+        #selected-fields:hover {
+            box-shadow: var(--sbb-control-shadow-hover);
+        }
+        #available-fields:focus,
+        #selected-fields:focus {
+            border-color: var(--sbb-control-border-focus);
+            box-shadow: var(--sbb-control-shadow-hover);
+        }
+        #available-fields option,
+        #selected-fields option {
+            padding: 4px 8px;
+        }
+        #available-fields option:hover,
+        #selected-fields option:hover,
+        #available-fields option:checked,
+        #selected-fields option:checked {
+            background-color: var(--sbb-option-hover);
+            color: var(--sbb-control-text);
+        }
+        #available-fields:focus option:checked,
+        #available-fields:focus option:checked:hover,
+        #selected-fields:focus option:checked,
+        #selected-fields:focus option:checked:hover {
+            background: #D1FFF2 linear-gradient(#D1FFF2, #D1FFF2) !important;
+            color: var(--sbb-control-text) !important;
+            -webkit-text-fill-color: var(--sbb-control-text);
+        }
+
     </style>
 </head>
 
@@ -86,7 +178,10 @@
 
         <div class="flex-container">
             <div class="column select-column">
-                <label for="available-fields">Available fields:</label>
+                <div class="available-fields-header">
+                    <label for="available-fields">Available fields:</label>
+                    <input type="text" id="available-fields-filter" class="filter-input" aria-label="Filter available fields">
+                </div>
                 <select id="available-fields" multiple size="22">
                 </select>
             </div>
@@ -101,28 +196,22 @@
             </div>
         </div>
 
-        <div class="flex-container" style="margin-top: 20px; padding-top: 16px; border-top: 1px solid #cccccc">
-            <div class="column select-column">
+        <div class="flex-container bottom-settings" style="margin-top: 20px; padding-top: 16px; border-top: 1px solid #cccccc">
+            <div class="column bottom-select-column">
                 <label for="statuses-to-ignore">Statuses of WorkItems in a source document to ignore when diffing:</label>
-                <select id="statuses-to-ignore" multiple size="10" style="height: 230px">
+                <select id="statuses-to-ignore" multiple>
                 </select>
             </div>
 
-            <div class="column buttons-column">
-                <%-- fake component. used just to emulate same gap betweeen areas in the top block--%>
-            </div>
-
-            <div id="hyperlink-settings-container" class="column select-column">
+            <div id="hyperlink-settings-container" class="column bottom-select-column">
                 <label for="hyperlink-roles">Hyperlink roles to diff and merge</label>
-                <input type="text" id="search-hyperlink-roles-input" placeholder="Filter items">
-                <select id="hyperlink-roles" multiple size="10" style="height: 200px">
+                <select id="hyperlink-roles" multiple>
                 </select>
             </div>
 
-            <div id="linked-workitem-settings-container" class="column select-column">
-                <label for="hyperlink-roles">Roles of linked WorkItems to diff and merge</label>
-                <input type="text" id="search-linked-workitem-roles-input" placeholder="Filter items">
-                <select id="linked-workitem-roles" multiple size="10" style="height: 200px">
+            <div id="linked-workitem-settings-container" class="column bottom-select-column">
+                <label for="linked-workitem-roles">Roles of linked WorkItems to diff and merge</label>
+                <select id="linked-workitem-roles" multiple>
                 </select>
             </div>
         </div>


### PR DESCRIPTION
Fixes #524

### Proposed changes

On the Diff Configuration admin page (diff-tool-admin/pages/configuration.jsp) there are several native multi-select listboxes that are the last controls in this extension not yet unified on our shared SearchableDropdown component. This PR covers replacing them with SearchableDropdown in multiselect mode (removable chips + built-in searchable dropdown).

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
