### PR TITLE
feat: make structural diff optional - when switched off only content diff will be shown

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1797,6 +1797,10 @@
           },
           "rightDocument": {
             "$ref": "#/components/schemas/DocumentIdentifier"
+          },
+          "syncStructure": {
+            "description": "Indicates whether structural changes (moved / added / deleted items) are included; when false only content changes of items present on both sides are returned. Defaults to true.",
+            "type": "boolean"
           }
         },
         "type": "object"

--- a/src/main/java/ch/sbb/polarion/extension/diff_tool/rest/model/diff/DocumentsDiffParams.java
+++ b/src/main/java/ch/sbb/polarion/extension/diff_tool/rest/model/diff/DocumentsDiffParams.java
@@ -2,6 +2,7 @@ package ch.sbb.polarion.extension.diff_tool.rest.model.diff;
 
 import ch.sbb.polarion.extension.diff_tool.rest.model.DocumentIdentifier;
 import ch.sbb.polarion.extension.generic.settings.NamedSettings;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -30,7 +31,15 @@ public class DocumentsDiffParams {
     @Schema(description = "The ID of the configuration cache bucket")
     private String configCacheBucketId;
 
+    @Schema(description = "Indicates whether structural changes (moved / added / deleted items) are included; when false only content changes of items present on both sides are returned. Defaults to true.")
+    private Boolean syncStructure;
+
     public String getConfigName() {
         return configName != null ? configName : NamedSettings.DEFAULT_NAME;
+    }
+
+    @JsonIgnore
+    public boolean isSyncStructureEnabled() {
+        return !Boolean.FALSE.equals(syncStructure); // default true when null
     }
 }

--- a/src/main/java/ch/sbb/polarion/extension/diff_tool/service/DiffService.java
+++ b/src/main/java/ch/sbb/polarion/extension/diff_tool/service/DiffService.java
@@ -213,9 +213,19 @@ public class DiffService {
 
         DiffModel diffModel = DiffModelCachedResource.get(leftDocumentIdentifier.getProjectId(), documentsDiffParams.getConfigName(), documentsDiffParams.getConfigCacheBucketId());
 
-        List<WorkItemsPair> pairedWorkItems = documentsDiffParams.isBranchedDocuments()
-                ? polarionService.getPairedWorkItems(leftDocument, rightDocument, true, linkRole, diffModel.getStatusesToIgnore())
-                : handleMovedItems(polarionService.getPairedWorkItems(leftDocument, rightDocument, false, linkRole, diffModel.getStatusesToIgnore()));
+        List<WorkItemsPair> pairedWorkItems = polarionService.getPairedWorkItems(leftDocument, rightDocument,
+                documentsDiffParams.isBranchedDocuments(), linkRole, diffModel.getStatusesToIgnore());
+        if (documentsDiffParams.isSyncStructureEnabled()) {
+            // Moved-item surrogates are only relevant when structure is synced (and only for non-branched documents)
+            if (!documentsDiffParams.isBranchedDocuments()) {
+                pairedWorkItems = handleMovedItems(pairedWorkItems);
+            }
+        } else {
+            // Structure sync disabled: drop structural (added/deleted) pairs, keep only content changes of items present on both sides
+            pairedWorkItems = pairedWorkItems.stream()
+                    .filter(pair -> pair.getLeftWorkItem() != null && pair.getRightWorkItem() != null)
+                    .toList();
+        }
 
         // Refresh workItems cache for both documents
         Subject userSubject = RequestContextUtil.getUserSubject();

--- a/src/test/java/ch/sbb/polarion/extension/diff_tool/rest/controller/DiffInternalControllerTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/diff_tool/rest/controller/DiffInternalControllerTest.java
@@ -67,13 +67,13 @@ class DiffInternalControllerTest {
 
     @Test
     void getDocumentsDiffThrowsWhenLeftDocumentMissing() {
-        DocumentsDiffParams params = new DocumentsDiffParams(null, mock(DocumentIdentifier.class), false, "role", null, null);
+        DocumentsDiffParams params = new DocumentsDiffParams(null, mock(DocumentIdentifier.class), false, "role", null, null, null);
         assertThrows(BadRequestException.class, () -> controller.getDocumentsDiff(params));
     }
 
     @Test
     void getDocumentsDiffThrowsWhenRightDocumentMissing() {
-        DocumentsDiffParams params = new DocumentsDiffParams(mock(DocumentIdentifier.class), null, false, "role", null, null);
+        DocumentsDiffParams params = new DocumentsDiffParams(mock(DocumentIdentifier.class), null, false, "role", null, null, null);
         assertThrows(BadRequestException.class, () -> controller.getDocumentsDiff(params));
     }
 
@@ -81,7 +81,7 @@ class DiffInternalControllerTest {
     void getDocumentsDiffThrowsWhenLinkRoleMissingForDifferentDocuments() {
         DocumentIdentifier left = DocumentIdentifier.builder().projectId("p").spaceId("s").name("a").build();
         DocumentIdentifier right = DocumentIdentifier.builder().projectId("p").spaceId("s").name("b").build();
-        DocumentsDiffParams params = new DocumentsDiffParams(left, right, false, null, null, null);
+        DocumentsDiffParams params = new DocumentsDiffParams(left, right, false, null, null, null, null);
         assertThrows(BadRequestException.class, () -> controller.getDocumentsDiff(params));
     }
 
@@ -89,7 +89,7 @@ class DiffInternalControllerTest {
     void getDocumentsDiffAllowsMissingLinkRoleWhenSameDocument() {
         DocumentIdentifier left = DocumentIdentifier.builder().projectId("p").spaceId("s").name("doc").revision("r1").build();
         DocumentIdentifier right = DocumentIdentifier.builder().projectId("p").spaceId("s").name("doc").revision("r2").build();
-        DocumentsDiffParams params = new DocumentsDiffParams(left, right, false, null, null, null);
+        DocumentsDiffParams params = new DocumentsDiffParams(left, right, false, null, null, null, null);
 
         DocumentsDiff expected = DocumentsDiff.builder().build();
         when(diffService.getDocumentsDiff(any())).thenReturn(expected);
@@ -102,7 +102,7 @@ class DiffInternalControllerTest {
         // Branched documents are paired via the fixed 'branched_from' role, so no explicit linkRole is required
         DocumentIdentifier left = DocumentIdentifier.builder().projectId("pA").spaceId("s").name("a").build();
         DocumentIdentifier right = DocumentIdentifier.builder().projectId("pB").spaceId("s").name("b").build();
-        DocumentsDiffParams params = new DocumentsDiffParams(left, right, true, null, null, null);
+        DocumentsDiffParams params = new DocumentsDiffParams(left, right, true, null, null, null, null);
 
         DocumentsDiff expected = DocumentsDiff.builder().build();
         when(diffService.getDocumentsDiff(any())).thenReturn(expected);
@@ -114,7 +114,7 @@ class DiffInternalControllerTest {
     void getDocumentsDiffPassesValidLinkRoleThrough() {
         DocumentIdentifier left = DocumentIdentifier.builder().projectId("pA").spaceId("s").name("doc").build();
         DocumentIdentifier right = DocumentIdentifier.builder().projectId("pB").spaceId("s").name("doc").build();
-        DocumentsDiffParams params = new DocumentsDiffParams(left, right, false, "relates-to", null, null);
+        DocumentsDiffParams params = new DocumentsDiffParams(left, right, false, "relates-to", null, null, null);
 
         DocumentsDiff expected = DocumentsDiff.builder().build();
         when(diffService.getDocumentsDiff(any())).thenReturn(expected);

--- a/src/test/java/ch/sbb/polarion/extension/diff_tool/rest/model/diff/DocumentsDiffParamsTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/diff_tool/rest/model/diff/DocumentsDiffParamsTest.java
@@ -2,11 +2,34 @@ package ch.sbb.polarion.extension.diff_tool.rest.model.diff;
 
 import ch.sbb.polarion.extension.diff_tool.rest.model.DocumentIdentifier;
 import ch.sbb.polarion.extension.generic.settings.NamedSettings;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.SneakyThrows;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 class DocumentsDiffParamsTest {
+
+    @Test
+    @SneakyThrows
+    void testSyncStructureDeserializesFromJson() {
+        ObjectMapper mapper = new ObjectMapper();
+
+        // Explicit false must be honoured (regression guard: a @JsonIgnore accessor colliding with the
+        // "syncStructure" property name would make Jackson drop the incoming value)
+        DocumentsDiffParams disabled = mapper.readValue("{\"syncStructure\": false}", DocumentsDiffParams.class);
+        assertEquals(Boolean.FALSE, disabled.getSyncStructure());
+        assertFalse(disabled.isSyncStructureEnabled());
+
+        DocumentsDiffParams enabled = mapper.readValue("{\"syncStructure\": true}", DocumentsDiffParams.class);
+        assertEquals(Boolean.TRUE, enabled.getSyncStructure());
+        assertTrue(enabled.isSyncStructureEnabled());
+
+        // Omitted ⇒ defaults to enabled (backward compatibility)
+        DocumentsDiffParams omitted = mapper.readValue("{}", DocumentsDiffParams.class);
+        assertNull(omitted.getSyncStructure());
+        assertTrue(omitted.isSyncStructureEnabled());
+    }
 
     @Test
     void testNoArgsConstructor() {
@@ -31,7 +54,7 @@ class DocumentsDiffParamsTest {
                 .name("rightDoc")
                 .build();
 
-        DocumentsDiffParams params = new DocumentsDiffParams(leftDoc, rightDoc, false, "linkRole", "customConfig", "bucketId");
+        DocumentsDiffParams params = new DocumentsDiffParams(leftDoc, rightDoc, false, "linkRole", "customConfig", "bucketId", null);
 
         assertEquals(leftDoc, params.getLeftDocument());
         assertEquals(rightDoc, params.getRightDocument());

--- a/src/test/java/ch/sbb/polarion/extension/diff_tool/service/DiffServiceTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/diff_tool/service/DiffServiceTest.java
@@ -364,7 +364,7 @@ class DiffServiceTest {
         DocumentIdentifier leftDocumentIdentifier = DocumentIdentifier.builder().projectId("project1").spaceId("space1").name("left").revision("rev1").build();
         DocumentIdentifier rightDocumentIdentifier = DocumentIdentifier.builder().projectId("project1").spaceId("space1").name("right").revision("rev1").build();
 
-        DocumentsContentDiff result = diffService.getDocumentsContentDiff(new DocumentsDiffParams(leftDocumentIdentifier, rightDocumentIdentifier, false, linkRole, NamedSettings.DEFAULT_NAME, null));
+        DocumentsContentDiff result = diffService.getDocumentsContentDiff(new DocumentsDiffParams(leftDocumentIdentifier, rightDocumentIdentifier, false, linkRole, NamedSettings.DEFAULT_NAME, null, null));
         assertNotNull(result);
         assertEquals(4, result.getPairedContentAnchors().size());
 
@@ -984,7 +984,7 @@ class DiffServiceTest {
         DocumentIdentifier leftDocumentIdentifier = DocumentIdentifier.builder().projectId("project1").spaceId("space1").name("left").revision("rev1").build();
         DocumentIdentifier rightDocumentIdentifier = DocumentIdentifier.builder().projectId("project1").spaceId("space1").name("right").revision("rev1").build();
 
-        DocumentsDiffParams params = new DocumentsDiffParams(leftDocumentIdentifier, rightDocumentIdentifier, false, "invalid-role", null, null);
+        DocumentsDiffParams params = new DocumentsDiffParams(leftDocumentIdentifier, rightDocumentIdentifier, false, "invalid-role", null, null, null);
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> diffService.getDocumentsDiff(params));
 
         assertTrue(exception.getMessage().contains("invalid-role"));
@@ -1000,8 +1000,8 @@ class DiffServiceTest {
         DocumentIdentifier leftDocumentIdentifier = DocumentIdentifier.builder().projectId("project1").spaceId("space1").name("left").revision("rev1").build();
         DocumentIdentifier rightDocumentIdentifier = DocumentIdentifier.builder().projectId("project1").spaceId("space1").name("right").revision("rev1").build();
 
-        DocumentsDiffParams nullRoleParams = new DocumentsDiffParams(leftDocumentIdentifier, rightDocumentIdentifier, false, null, null, null);
-        DocumentsDiffParams emptyRoleParams = new DocumentsDiffParams(leftDocumentIdentifier, rightDocumentIdentifier, false, "", null, null);
+        DocumentsDiffParams nullRoleParams = new DocumentsDiffParams(leftDocumentIdentifier, rightDocumentIdentifier, false, null, null, null, null);
+        DocumentsDiffParams emptyRoleParams = new DocumentsDiffParams(leftDocumentIdentifier, rightDocumentIdentifier, false, "", null, null, null);
         assertThrows(IllegalArgumentException.class, () -> diffService.getDocumentsDiff(nullRoleParams));
         assertThrows(IllegalArgumentException.class, () -> diffService.getDocumentsDiff(emptyRoleParams));
         verify(polarionService, never()).getLinkRoleById(anyString(), any());
@@ -1027,8 +1027,8 @@ class DiffServiceTest {
                      mockStatic(ch.sbb.polarion.extension.diff_tool.util.DiffModelCachedResource.class)) {
             mockedDiffModel.when(() -> ch.sbb.polarion.extension.diff_tool.util.DiffModelCachedResource.get(any(), any(), any()))
                     .thenReturn(ch.sbb.polarion.extension.diff_tool.rest.model.settings.DiffModel.builder().build());
-            assertNotNull(diffService.getDocumentsDiff(new DocumentsDiffParams(leftDocumentIdentifier, rightDocumentIdentifier, false, null, null, null)));
-            assertNotNull(diffService.getDocumentsDiff(new DocumentsDiffParams(leftDocumentIdentifier, rightDocumentIdentifier, false, "", null, null)));
+            assertNotNull(diffService.getDocumentsDiff(new DocumentsDiffParams(leftDocumentIdentifier, rightDocumentIdentifier, false, null, null, null, null)));
+            assertNotNull(diffService.getDocumentsDiff(new DocumentsDiffParams(leftDocumentIdentifier, rightDocumentIdentifier, false, "", null, null, null)));
         } finally {
             org.springframework.web.context.request.RequestContextHolder.resetRequestAttributes();
         }
@@ -1063,7 +1063,7 @@ class DiffServiceTest {
             mockedDiffModel.when(() -> ch.sbb.polarion.extension.diff_tool.util.DiffModelCachedResource.get(any(), any(), any()))
                     .thenReturn(ch.sbb.polarion.extension.diff_tool.rest.model.settings.DiffModel.builder().build());
 
-            DocumentsDiff result = diffService.getDocumentsDiff(new DocumentsDiffParams(left, right, true, null, null, null));
+            DocumentsDiff result = diffService.getDocumentsDiff(new DocumentsDiffParams(left, right, true, null, null, null, null));
 
             assertNotNull(result);
             // Branched diff passes the paired work items through as-is (moved-items surrogate handling must be skipped)
@@ -1079,6 +1079,99 @@ class DiffServiceTest {
     }
 
     @Test
+    void testGetDocumentsDiffOmitsStructuralPairsWhenSyncStructureDisabled() {
+        IModule document = mockSameDocumentForDiff();
+        when(polarionService.getDocumentWithFilledRevision("project1", "space1", "doc", "rev1")).thenReturn(document);
+        when(polarionService.getDocumentWithFilledRevision("project1", "space1", "doc", "rev2")).thenReturn(document);
+        when(polarionService.getDocumentWorkItemsCache()).thenReturn(mock(ch.sbb.polarion.extension.diff_tool.util.DocumentWorkItemsCache.class));
+
+        WorkItemsPair fullPair = WorkItemsPair.builder()
+                .leftWorkItem(WorkItem.builder().id("AA-1").outlineNumber("1-1").build())
+                .rightWorkItem(WorkItem.builder().id("AA-2").outlineNumber("1-1").build())
+                .build();
+        WorkItemsPair addedPair = WorkItemsPair.builder()
+                .leftWorkItem(null)
+                .rightWorkItem(WorkItem.builder().id("AA-3").outlineNumber("2-1").build())
+                .build();
+        WorkItemsPair deletedPair = WorkItemsPair.builder()
+                .leftWorkItem(WorkItem.builder().id("AA-4").outlineNumber("3-1").build())
+                .rightWorkItem(null)
+                .build();
+        when(polarionService.getPairedWorkItems(eq(document), eq(document), eq(false), isNull(), anyList()))
+                .thenReturn(new ArrayList<>(List.of(fullPair, addedPair, deletedPair)));
+
+        DocumentIdentifier left = DocumentIdentifier.builder().projectId("project1").spaceId("space1").name("doc").revision("rev1").build();
+        DocumentIdentifier right = DocumentIdentifier.builder().projectId("project1").spaceId("space1").name("doc").revision("rev2").build();
+
+        org.springframework.web.context.request.ServletRequestAttributes attrs =
+                mock(org.springframework.web.context.request.ServletRequestAttributes.class);
+        when(attrs.getRequest()).thenReturn(mock(jakarta.servlet.http.HttpServletRequest.class));
+        org.springframework.web.context.request.RequestContextHolder.setRequestAttributes(attrs);
+        try (org.mockito.MockedStatic<ch.sbb.polarion.extension.diff_tool.util.DiffModelCachedResource> mockedDiffModel =
+                     mockStatic(ch.sbb.polarion.extension.diff_tool.util.DiffModelCachedResource.class)) {
+            mockedDiffModel.when(() -> ch.sbb.polarion.extension.diff_tool.util.DiffModelCachedResource.get(any(), any(), any()))
+                    .thenReturn(ch.sbb.polarion.extension.diff_tool.rest.model.settings.DiffModel.builder().build());
+
+            DocumentsDiffParams params = new DocumentsDiffParams(left, right, false, null, null, null, false);
+            DocumentsDiff result = diffService.getDocumentsDiff(params);
+
+            assertNotNull(result);
+            // With structure sync disabled only pairs present on both sides are kept (added/deleted are dropped)
+            assertEquals(1, result.getPairedWorkItems().size());
+            WorkItemsPair remaining = result.getPairedWorkItems().iterator().next();
+            assertEquals("AA-1", remaining.getLeftWorkItem().getId());
+            assertEquals("AA-2", remaining.getRightWorkItem().getId());
+            // Moved-items handling is skipped, so no pair carries a move marker
+            assertNull(remaining.getLeftWorkItem().getMovedOutlineNumber());
+            assertNull(remaining.getLeftWorkItem().getMoveDirection());
+        } finally {
+            org.springframework.web.context.request.RequestContextHolder.resetRequestAttributes();
+        }
+    }
+
+    @Test
+    void testGetDocumentsDiffKeepsStructuralPairsWhenSyncStructureDefaultsTrue() {
+        IModule document = mockSameDocumentForDiff();
+        when(polarionService.getDocumentWithFilledRevision("project1", "space1", "doc", "rev1")).thenReturn(document);
+        when(polarionService.getDocumentWithFilledRevision("project1", "space1", "doc", "rev2")).thenReturn(document);
+        when(polarionService.getDocumentWorkItemsCache()).thenReturn(mock(ch.sbb.polarion.extension.diff_tool.util.DocumentWorkItemsCache.class));
+
+        // Root outline numbers that are equal ⇒ handleMovedItems detects no move (no surrogate creation)
+        WorkItemsPair fullPair = WorkItemsPair.builder()
+                .leftWorkItem(WorkItem.builder().id("AA-1").outlineNumber("1").build())
+                .rightWorkItem(WorkItem.builder().id("AA-2").outlineNumber("1").build())
+                .build();
+        WorkItemsPair addedPair = WorkItemsPair.builder()
+                .leftWorkItem(null)
+                .rightWorkItem(WorkItem.builder().id("AA-3").outlineNumber("2").build())
+                .build();
+        when(polarionService.getPairedWorkItems(eq(document), eq(document), eq(false), isNull(), anyList()))
+                .thenReturn(new ArrayList<>(List.of(fullPair, addedPair)));
+
+        DocumentIdentifier left = DocumentIdentifier.builder().projectId("project1").spaceId("space1").name("doc").revision("rev1").build();
+        DocumentIdentifier right = DocumentIdentifier.builder().projectId("project1").spaceId("space1").name("doc").revision("rev2").build();
+
+        org.springframework.web.context.request.ServletRequestAttributes attrs =
+                mock(org.springframework.web.context.request.ServletRequestAttributes.class);
+        when(attrs.getRequest()).thenReturn(mock(jakarta.servlet.http.HttpServletRequest.class));
+        org.springframework.web.context.request.RequestContextHolder.setRequestAttributes(attrs);
+        try (org.mockito.MockedStatic<ch.sbb.polarion.extension.diff_tool.util.DiffModelCachedResource> mockedDiffModel =
+                     mockStatic(ch.sbb.polarion.extension.diff_tool.util.DiffModelCachedResource.class)) {
+            mockedDiffModel.when(() -> ch.sbb.polarion.extension.diff_tool.util.DiffModelCachedResource.get(any(), any(), any()))
+                    .thenReturn(ch.sbb.polarion.extension.diff_tool.rest.model.settings.DiffModel.builder().build());
+
+            // syncStructure omitted (6-arg constructor) ⇒ defaults to true ⇒ structural (added) pair retained
+            DocumentsDiffParams params = new DocumentsDiffParams(left, right, false, null, null, null, null);
+            DocumentsDiff result = diffService.getDocumentsDiff(params);
+
+            assertNotNull(result);
+            assertEquals(2, result.getPairedWorkItems().size());
+        } finally {
+            org.springframework.web.context.request.RequestContextHolder.resetRequestAttributes();
+        }
+    }
+
+    @Test
     void testGetDocumentsDiffRequiresLinkRoleWhenProjectDiffers() {
         IModule leftDocument = mock(IModule.class);
         IModule rightDocument = mock(IModule.class);
@@ -1088,7 +1181,7 @@ class DiffServiceTest {
         DocumentIdentifier left = DocumentIdentifier.builder().projectId("projectA").spaceId("space1").name("doc").build();
         DocumentIdentifier right = DocumentIdentifier.builder().projectId("projectB").spaceId("space1").name("doc").build();
 
-        DocumentsDiffParams params = new DocumentsDiffParams(left, right, false, null, null, null);
+        DocumentsDiffParams params = new DocumentsDiffParams(left, right, false, null, null, null, null);
         assertThrows(IllegalArgumentException.class, () -> diffService.getDocumentsDiff(params));
     }
 
@@ -1103,7 +1196,7 @@ class DiffServiceTest {
         DocumentIdentifier right = DocumentIdentifier.builder().projectId("project1").spaceId("space2").name("doc").build();
 
         // Same project + name, but different space ⇒ documents differ ⇒ linkRole still required.
-        DocumentsDiffParams params = new DocumentsDiffParams(left, right, false, null, null, null);
+        DocumentsDiffParams params = new DocumentsDiffParams(left, right, false, null, null, null, null);
         assertThrows(IllegalArgumentException.class, () -> diffService.getDocumentsDiff(params));
     }
 
@@ -1118,7 +1211,7 @@ class DiffServiceTest {
         DocumentIdentifier right = DocumentIdentifier.builder().projectId("project1").spaceId("space1").name("right").build();
 
         // Same project + space, but different name ⇒ documents differ ⇒ linkRole still required.
-        DocumentsDiffParams params = new DocumentsDiffParams(left, right, false, null, null, null);
+        DocumentsDiffParams params = new DocumentsDiffParams(left, right, false, null, null, null, null);
         assertThrows(IllegalArgumentException.class, () -> diffService.getDocumentsDiff(params));
     }
 
@@ -1134,7 +1227,7 @@ class DiffServiceTest {
         DocumentIdentifier leftDocumentIdentifier = DocumentIdentifier.builder().projectId("project1").spaceId("space1").name("doc").revision("rev1").build();
         DocumentIdentifier rightDocumentIdentifier = DocumentIdentifier.builder().projectId("project1").spaceId("space1").name("doc").revision("rev2").build();
 
-        assertNotNull(diffService.getDocumentsContentDiff(new DocumentsDiffParams(leftDocumentIdentifier, rightDocumentIdentifier, false, null, NamedSettings.DEFAULT_NAME, null)));
+        assertNotNull(diffService.getDocumentsContentDiff(new DocumentsDiffParams(leftDocumentIdentifier, rightDocumentIdentifier, false, null, NamedSettings.DEFAULT_NAME, null, null)));
         verify(polarionService, never()).getLinkRoleById(anyString(), any());
     }
 
@@ -1156,7 +1249,7 @@ class DiffServiceTest {
         DocumentIdentifier left = DocumentIdentifier.builder().projectId("project1").spaceId("space1").name("left").build();
         DocumentIdentifier right = DocumentIdentifier.builder().projectId("project1").spaceId("space1").name("right").build();
 
-        DocumentsContentDiff result = diffService.getDocumentsContentDiff(new DocumentsDiffParams(left, right, true, null, NamedSettings.DEFAULT_NAME, null));
+        DocumentsContentDiff result = diffService.getDocumentsContentDiff(new DocumentsDiffParams(left, right, true, null, NamedSettings.DEFAULT_NAME, null, null));
 
         assertNotNull(result);
         // Branched content diff resolves the fixed 'branched_from' role and additionally pairs paragraphs by title

--- a/ui/src/components/ControlPane.js
+++ b/ui/src/components/ControlPane.js
@@ -217,6 +217,15 @@ export default function ControlPane({diff_type}) {
                 </label>
               </div>
           }
+          {(diff_type === DiffTypes.DOCUMENTS_DIFF || diff_type === DiffTypes.COLLECTIONS_DIFF) &&
+              <div className="form-check">
+                <input className="form-check-input" type="checkbox" checked={context.state.syncStructure} id="sync-structure"
+                       onChange={() => context.state.setSyncStructure(!context.state.syncStructure)}/>
+                <label className="form-check-label" htmlFor="sync-structure" title="When unchecked, moved, added and removed items are hidden and only content changes of items present in both documents are compared and merged.">
+                  Sync structure
+                </label>
+              </div>
+          }
           {diff_type !== DiffTypes.DOCUMENTS_FIELDS_DIFF && diff_type !== DiffTypes.DOCUMENTS_CONTENT_DIFF &&
               <div className="form-check">
                 <input className="form-check-input" type="checkbox" value="" id="counterparts-differ"

--- a/ui/src/components/documents/DocumentsContentDiff.js
+++ b/ui/src/components/documents/DocumentsContentDiff.js
@@ -50,8 +50,16 @@ export default function DocumentsContentDiff({ enclosingCollections }) {
       return;
     }
 
+    let ignore = false; // guard against a superseded request overwriting docsData with stale results
     diffService.sendDocumentsContentDiffRequest(searchParams, uuidv4(), loadingContext)
-        .then((data) => setDocsData(data));
+        .then((data) => {
+          if (!ignore) {
+            setDocsData(data);
+          }
+        });
+    return () => {
+      ignore = true;
+    };
   }, [searchParams]);
 
   useEffect(() => {

--- a/ui/src/components/documents/DocumentsDiff.js
+++ b/ui/src/components/documents/DocumentsDiff.js
@@ -72,9 +72,9 @@ export default function DocumentsDiff({ enclosingCollections }) {
     const cacheId = uuidv4();
     setConfigCacheId(cacheId);
 
-    diffService.sendDocumentsDiffRequest(searchParams, cacheId, loadingContext)
+    diffService.sendDocumentsDiffRequest(searchParams, cacheId, loadingContext, context.state.syncStructure)
         .then((data) => setDocsData(data));
-  }, [searchParams]);
+  }, [searchParams, context.state.syncStructure]);
 
   useEffect(() => {
     if (docsData && docsData.pairedWorkItems && docsData.pairedWorkItems.length > 0) {

--- a/ui/src/components/documents/DocumentsDiff.js
+++ b/ui/src/components/documents/DocumentsDiff.js
@@ -72,8 +72,16 @@ export default function DocumentsDiff({ enclosingCollections }) {
     const cacheId = uuidv4();
     setConfigCacheId(cacheId);
 
+    let ignore = false; // guard against a superseded request overwriting docsData with stale results
     diffService.sendDocumentsDiffRequest(searchParams, cacheId, loadingContext, context.state.syncStructure)
-        .then((data) => setDocsData(data));
+        .then((data) => {
+          if (!ignore) {
+            setDocsData(data);
+          }
+        });
+    return () => {
+      ignore = true;
+    };
   }, [searchParams, context.state.syncStructure]);
 
   useEffect(() => {

--- a/ui/src/components/documents/DocumentsFieldsDiff.js
+++ b/ui/src/components/documents/DocumentsFieldsDiff.js
@@ -1,4 +1,4 @@
-import {useContext, useEffect, useState} from "react";
+import {useContext, useEffect, useRef, useState} from "react";
 import {useSearchParams} from "next/navigation";
 import AppContext from "../AppContext";
 import AppAlert from "@/components/AppAlert";
@@ -42,6 +42,7 @@ export default function DocumentsFieldsDiff({ enclosingCollections }) {
   const [mergeDeniedWarning, setMergeDeniedWarning] = useState(false);  // means that merge operation was denied because displayed state of documents is not last one
   const [mergeNotAuthorizedWarning, setMergeNotAuthorizedWarning] = useState(false);  // means that merge to target document is not authorized for current user
   const [mergeReportModalVisible, setMergeReportModalVisible] = useState(false);
+  const latestRequestRef = useRef(0);
 
   useEffect(() => {
     const missingParams = REQUIRED_PARAMS.filter(param => !searchParams.get(param));
@@ -55,9 +56,14 @@ export default function DocumentsFieldsDiff({ enclosingCollections }) {
   }, [searchParams]);
 
   const loadDiff = () => {
+    // Guard against a superseded request overwriting state with stale results (deps/settings can change while in flight)
+    const requestId = ++latestRequestRef.current;
     mergingContext.resetRegistry();
     diffService.sendDocumentsFieldsDiffRequest(searchParams, context.state.compareEnumsById, context.state.compareOnlyMutualFields, loadingContext)
         .then((data)=> {
+              if (requestId !== latestRequestRef.current) {
+                return;
+              }
               setFieldsData(data);
               let diffs = data.pairedFields.filter(fieldDiff => fieldDiff.leftField.htmlDiff && fieldDiff.rightField.htmlDiff).map((fieldDiff, index) => {
                 mergingContext.setPairSelected(index, fieldDiff.leftField.id, false);

--- a/ui/src/components/documents/workitems/WorkItemsPairDiff.js
+++ b/ui/src/components/documents/workitems/WorkItemsPairDiff.js
@@ -1,5 +1,5 @@
 import DiffContent from "@/components/diff/DiffContent";
-import {useContext, useEffect, useMemo, useState} from "react";
+import {useContext, useEffect, useMemo, useRef, useState} from "react";
 import {WorkItemHeader, LEFT, RIGHT} from "@/components/WorkItemHeader";
 import FloatingButton from "@/components/FloatingButton";
 import {faChevronDown, faChevronUp, faEquals, faQuestion} from "@fortawesome/free-solid-svg-icons";
@@ -37,6 +37,7 @@ export default function WorkItemsPairDiff({ leftDocument, rightDocument, workIte
   const [selected, setSelected] = useState(mergingContext.isIndexSelected(currentIndex));
   const [pairSelectionTrigger, setPairSelectionTrigger] = useState(0);
   const [childrenSelectionModalVisible, setChildrenSelectionModalVisible] = useState(false);
+  const latestRequestRef = useRef(0); // guards against a superseded (or retried) request overwriting diffData with stale results
 
   const branchedDocuments = useMemo(() => searchParams.get('branched') === "true", [searchParams]);
 
@@ -113,7 +114,7 @@ export default function WorkItemsPairDiff({ leftDocument, rightDocument, workIte
         body.rightWorkItem.revision = workItemsPair.rightWorkItem.revision;
       }
     }
-    requestDiff(body, 0);
+    requestDiff(body, 0, ++latestRequestRef.current);
   }, [onHold]);
 
   useEffect(() => {
@@ -200,7 +201,7 @@ export default function WorkItemsPairDiff({ leftDocument, rightDocument, workIte
     return reportEntry && reportEntry.workItemsPair;
   };
 
-  const requestDiff = (body, triesCount) => {
+  const requestDiff = (body, triesCount, requestId) => {
     setLoading(true);
     setDataLoadedFired(false);
     remote.sendRequest({
@@ -214,7 +215,9 @@ export default function WorkItemsPairDiff({ leftDocument, rightDocument, workIte
       } else {
         if (CODES_TO_RETRY.includes(response.status) && triesCount < 3) {
           setTimeout(() => {
-            requestDiff(body, triesCount + 1);
+            if (requestId === latestRequestRef.current) { // do not retry a superseded request
+              requestDiff(body, triesCount + 1, requestId);
+            }
           }, triesCount * 2000 + 1000);
           throw Promise.resolve(RETRY_MARKER); // Marker for later code that we are still trying to obtain diff from server
         } else {
@@ -222,6 +225,9 @@ export default function WorkItemsPairDiff({ leftDocument, rightDocument, workIte
         }
       }
     }).then(data =>  {
+      if (requestId !== latestRequestRef.current) {
+        return; // a newer request has superseded this one, ignore its (stale) result
+      }
       // ----- We need to reload title/outlineNumber information in case if they were modified by merge
       if (data.leftWorkItem) {
         workItemsPair.leftWorkItem.title = data.leftWorkItem.title;
@@ -236,6 +242,9 @@ export default function WorkItemsPairDiff({ leftDocument, rightDocument, workIte
       setLoading(false);
     }).catch(errorResponse => {
       Promise.resolve(errorResponse).then((error) => {
+        if (requestId !== latestRequestRef.current) {
+          return; // superseded request, ignore its error too
+        }
         if (RETRY_MARKER !== error) {
           setError(error && error.message ? error.message : "Error occurred loading diff data");
           setLoading(false);

--- a/ui/src/components/workitems/WorkItemsDiff.js
+++ b/ui/src/components/workitems/WorkItemsDiff.js
@@ -66,11 +66,18 @@ export default function WorkItemsDiff() {
 
     setConfigCacheId(uuidv4());
 
+    let ignore = false; // guard against a superseded request overwriting workItemsData with stale results
     diffService.sendFindWorkItemsPairsRequest(searchParams, loadingContext)
         .then((data) => {
+          if (ignore) {
+            return;
+          }
           setWorkItemsData(data);
           setRedundancyModalVisible(data.leftWorkItemIdsWithRedundancy && data.leftWorkItemIdsWithRedundancy.length > 0);
         });
+    return () => {
+      ignore = true;
+    };
   }, [searchParams]);
 
   useEffect(() => {

--- a/ui/src/components/workitems/WorkItemsPairDiff.js
+++ b/ui/src/components/workitems/WorkItemsPairDiff.js
@@ -1,6 +1,6 @@
 import PairMergeTicker from "@/components/merge/PairMergeTicker";
 import {LEFT, RIGHT, WorkItemHeader} from "@/components/WorkItemHeader";
-import {useContext, useEffect, useState} from "react";
+import {useContext, useEffect, useRef, useState} from "react";
 import useImageUtils from "@/utils/useImageUtils";
 import DiffContent from "@/components/diff/DiffContent";
 import useRemote from "@/services/useRemote";
@@ -28,6 +28,7 @@ export default function WorkItemsPairDiff({ workItemsPair, leftProject, rightPro
   const [dataLoadedFired, setDataLoadedFired] = useState(false);
   const [selected, setSelected] = useState(mergingContext.isIndexSelected(currentIndex));
   const [pairSelectionTrigger, setPairSelectionTrigger] = useState(0);
+  const latestRequestRef = useRef(0); // guards against a superseded (or retried) request overwriting diffData with stale results
 
   useEffect(() => {
     if (onHold && loadingContext.pairLoadingAllowed(currentIndex)) {
@@ -84,7 +85,7 @@ export default function WorkItemsPairDiff({ workItemsPair, leftProject, rightPro
         }
       }
     }
-    requestDiff(body, 0);
+    requestDiff(body, 0, ++latestRequestRef.current);
   }, [onHold]);
 
   useEffect(() => {
@@ -150,7 +151,7 @@ export default function WorkItemsPairDiff({ workItemsPair, leftProject, rightPro
     setExpanded(!expanded);
   };
 
-  const requestDiff = (body, triesCount) => {
+  const requestDiff = (body, triesCount, requestId) => {
     setLoading(true);
     setDataLoadedFired(false);
     remote.sendRequest({
@@ -164,7 +165,9 @@ export default function WorkItemsPairDiff({ workItemsPair, leftProject, rightPro
       } else {
         if (CODES_TO_RETRY.includes(response.status) && triesCount < 3) {
           setTimeout(() => {
-            requestDiff(body, triesCount + 1);
+            if (requestId === latestRequestRef.current) { // do not retry a superseded request
+              requestDiff(body, triesCount + 1, requestId);
+            }
           }, triesCount * 2000 + 1000);
           throw Promise.resolve(RETRY_MARKER); // Marker for later code that we are still trying to obtain diff from server
         } else {
@@ -172,6 +175,9 @@ export default function WorkItemsPairDiff({ workItemsPair, leftProject, rightPro
         }
       }
     }).then(data =>  {
+      if (requestId !== latestRequestRef.current) {
+        return; // a newer request has superseded this one, ignore its (stale) result
+      }
       // ----- We need to reload title/outlineNumber information in case if they were modified by merge
       if (data.leftWorkItem) {
         workItemsPair.leftWorkItem.title = data.leftWorkItem.title;
@@ -184,6 +190,9 @@ export default function WorkItemsPairDiff({ workItemsPair, leftProject, rightPro
       setLoading(false);
     }).catch(errorResponse => {
       Promise.resolve(errorResponse).then((error) => {
+        if (requestId !== latestRequestRef.current) {
+          return; // superseded request, ignore its error too
+        }
         if (RETRY_MARKER !== error) {
           setError(error && error.message ? error.message : "Error occurred loading diff data");
           setLoading(false);

--- a/ui/src/services/useDiffService.js
+++ b/ui/src/services/useDiffService.js
@@ -4,7 +4,7 @@ import {CONTENT_ABOVE, CONTENT_BELOW} from "@/components/documents/ContentAnchor
 export default function useDiffService() {
   const remote = useRemote();
 
-  const sendDocumentsDiffRequest = (searchParams, configCacheId, loadingContext) => {
+  const sendDocumentsDiffRequest = (searchParams, configCacheId, loadingContext, syncStructure) => {
     const leftDocument = getDocumentFromSearchParams(searchParams, 'source');
     const rightDocument = getDocumentFromSearchParams(searchParams, 'target');
 
@@ -20,7 +20,8 @@ export default function useDiffService() {
           branchedDocuments: searchParams.get('branched'),
           linkRole: searchParams.get('linkRole'),
           configName: searchParams.get('config'),
-          configCacheBucketId: configCacheId
+          configCacheBucketId: configCacheId,
+          syncStructure: syncStructure
         }),
         contentType: "application/json"
       })

--- a/ui/src/useAppContext.js
+++ b/ui/src/useAppContext.js
@@ -6,6 +6,7 @@ export function useAppContext(){
   const [controlPaneExpanded, setControlPaneExpanded] = useState(false);
   const [pairedDocuments, setPairedDocuments] = useState([]);
   const [showOutlineNumbersDiff, setShowOutlineNumbersDiff] = useState(false);
+  const [syncStructure, setSyncStructure] = useState(true);
   const [counterpartWorkItemsDiffer, setCounterpartWorkItemsDiffer] = useState(false);
   const [compareOnlyMutualFields, setCompareOnlyMutualFields] = useState(true);
   const [compareEnumsById, setCompareEnumsById] = useState(false);
@@ -73,6 +74,8 @@ export function useAppContext(){
     setPairedDocuments,
     showOutlineNumbersDiff,
     setShowOutlineNumbersDiff,
+    syncStructure,
+    setSyncStructure,
     counterpartWorkItemsDiffer,
     setCounterpartWorkItemsDiffer,
     compareOnlyMutualFields,


### PR DESCRIPTION
Make structure sync optional                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                 
Closes #563                                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                 
### Proposed changes

The Diff-Tool syncs data (field/content values) and structure (moved/reordered items, and items added/removed) at the same time. The structural operations — moving items in the document tree and creating/deleting items — sometimes fail, and in many cases structural changes are not important. This makes structure sync optional via a sidebar option.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
