### PR TITLE
feat: make structural diff optional - when switched off only content diff will be shown

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1793,6 +1793,10 @@
           },
           "rightDocument": {
             "$ref": "#/components/schemas/DocumentIdentifier"
+          },
+          "syncStructure": {
+            "description": "Indicates whether structural changes (moved / added / deleted items) are included; when false only content changes of items present on both sides are returned. Defaults to true.",
+            "type": "boolean"
           }
         },
         "type": "object"

--- a/src/main/java/ch/sbb/polarion/extension/diff_tool/report/MergeReportEntry.java
+++ b/src/main/java/ch/sbb/polarion/extension/diff_tool/report/MergeReportEntry.java
@@ -10,6 +10,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.VisibleForTesting;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 
 @Getter
 @EqualsAndHashCode
@@ -33,14 +34,14 @@ public class MergeReportEntry {
         this.operationResultType = operationResultType;
         this.workItemsPair = workItemsPair;
         this.description = description;
-        this.operationTime = LocalDateTime.now();
+        this.operationTime = LocalDateTime.now(ZoneId.systemDefault());
     }
 
     public MergeReportEntry(@NotNull MergeReport.OperationResultType operationResultType, @NotNull String fieldId, @NotNull String description) {
         this.operationResultType = operationResultType;
         this.fieldId = fieldId;
         this.description = description;
-        this.operationTime = LocalDateTime.now();
+        this.operationTime = LocalDateTime.now(ZoneId.systemDefault());
     }
 
     @VisibleForTesting
@@ -56,7 +57,7 @@ public class MergeReportEntry {
         this.operationResultType = operationResultType;
         this.documentsContentPair = documentsContentPair;
         this.description = description;
-        this.operationTime = LocalDateTime.now();
+        this.operationTime = LocalDateTime.now(ZoneId.systemDefault());
     }
 
 }

--- a/src/main/java/ch/sbb/polarion/extension/diff_tool/rest/controller/DiffInternalController.java
+++ b/src/main/java/ch/sbb/polarion/extension/diff_tool/rest/controller/DiffInternalController.java
@@ -85,10 +85,7 @@ public class DiffInternalController {
                 && !documentsDiffParams.getLeftDocument().pointsToSameDocumentAs(documentsDiffParams.getRightDocument()))) {
             throw new BadRequestException("Parameters 'leftDocument', 'rightDocument' and 'linkRole' should be provided");
         }
-        return schedule(DIFF_DOCUMENTS, () ->
-                diffService.getDocumentsDiff(documentsDiffParams.getLeftDocument(), documentsDiffParams.getRightDocument(), documentsDiffParams.getLinkRole(),
-                        documentsDiffParams.getConfigName(), documentsDiffParams.getConfigCacheBucketId())
-        );
+        return schedule(DIFF_DOCUMENTS, () -> diffService.getDocumentsDiff(documentsDiffParams));
     }
 
     @POST

--- a/src/main/java/ch/sbb/polarion/extension/diff_tool/rest/model/diff/Document.java
+++ b/src/main/java/ch/sbb/polarion/extension/diff_tool/rest/model/diff/Document.java
@@ -57,6 +57,12 @@ public class Document {
         return this;
     }
 
+    @Nullable
+    public static Document from(@Nullable IModule module, boolean authorizedForMerge) {
+        Document document = from(module);
+        return document == null ? null : document.authorizedForMerge(authorizedForMerge);
+    }
+
     public static Document from(@Nullable IModule module) {
         if (module == null) {
             return null;

--- a/src/main/java/ch/sbb/polarion/extension/diff_tool/rest/model/diff/DocumentsDiffParams.java
+++ b/src/main/java/ch/sbb/polarion/extension/diff_tool/rest/model/diff/DocumentsDiffParams.java
@@ -2,6 +2,7 @@ package ch.sbb.polarion.extension.diff_tool.rest.model.diff;
 
 import ch.sbb.polarion.extension.diff_tool.rest.model.DocumentIdentifier;
 import ch.sbb.polarion.extension.generic.settings.NamedSettings;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -27,7 +28,15 @@ public class DocumentsDiffParams {
     @Schema(description = "The ID of the configuration cache bucket")
     private String configCacheBucketId;
 
+    @Schema(description = "Indicates whether structural changes (moved / added / deleted items) are included; when false only content changes of items present on both sides are returned. Defaults to true.")
+    private Boolean syncStructure;
+
     public String getConfigName() {
         return configName != null ? configName : NamedSettings.DEFAULT_NAME;
+    }
+
+    @JsonIgnore
+    public boolean isSyncStructureEnabled() {
+        return !Boolean.FALSE.equals(syncStructure); // default true when null
     }
 }

--- a/src/main/java/ch/sbb/polarion/extension/diff_tool/service/DiffService.java
+++ b/src/main/java/ch/sbb/polarion/extension/diff_tool/service/DiffService.java
@@ -13,6 +13,7 @@ import ch.sbb.polarion.extension.diff_tool.rest.model.diff.DocumentWorkItemsPair
 import ch.sbb.polarion.extension.diff_tool.rest.model.diff.DocumentsCollection;
 import ch.sbb.polarion.extension.diff_tool.rest.model.diff.DocumentsContentDiff;
 import ch.sbb.polarion.extension.diff_tool.rest.model.diff.DocumentsDiff;
+import ch.sbb.polarion.extension.diff_tool.rest.model.diff.DocumentsDiffParams;
 import ch.sbb.polarion.extension.diff_tool.rest.model.diff.DocumentsFieldsDiff;
 import ch.sbb.polarion.extension.diff_tool.rest.model.diff.DocumentsFieldsPair;
 import ch.sbb.polarion.extension.diff_tool.rest.model.diff.DocumentsPair;
@@ -163,16 +164,28 @@ public class DiffService {
         }
     }
 
-    public DocumentsDiff getDocumentsDiff(DocumentIdentifier leftDocumentIdentifier, DocumentIdentifier rightDocumentIdentifier, String linkRoleId, String configName, String configCacheBucketId) {
+    public DocumentsDiff getDocumentsDiff(DocumentsDiffParams documentsDiffParams) {
+        DocumentIdentifier leftDocumentIdentifier = documentsDiffParams.getLeftDocument();
+        DocumentIdentifier rightDocumentIdentifier = documentsDiffParams.getRightDocument();
         IModule leftDocument = polarionService.getDocumentWithFilledRevision(leftDocumentIdentifier.getProjectId(), leftDocumentIdentifier.getSpaceId(),
                 leftDocumentIdentifier.getName(), leftDocumentIdentifier.getRevision());
         IModule rightDocument = polarionService.getDocumentWithFilledRevision(rightDocumentIdentifier.getProjectId(), rightDocumentIdentifier.getSpaceId(),
                 rightDocumentIdentifier.getName(), rightDocumentIdentifier.getRevision());
-        ILinkRoleOpt linkRole = resolveLinkRole(linkRoleId, leftDocument, leftDocumentIdentifier, rightDocumentIdentifier);
 
-        DiffModel diffModel = DiffModelCachedResource.get(leftDocumentIdentifier.getProjectId(), configName, configCacheBucketId);
+        ILinkRoleOpt linkRole = resolveLinkRole(documentsDiffParams.getLinkRole(), leftDocument, leftDocumentIdentifier, rightDocumentIdentifier);
 
-        List<WorkItemsPair> pairedWorkItems = handleMovedItems(polarionService.getPairedWorkItems(leftDocument, rightDocument, linkRole, diffModel.getStatusesToIgnore()));
+        DiffModel diffModel = DiffModelCachedResource.get(leftDocumentIdentifier.getProjectId(), documentsDiffParams.getConfigName(), documentsDiffParams.getConfigCacheBucketId());
+
+        List<WorkItemsPair> pairedWorkItems = polarionService.getPairedWorkItems(leftDocument, rightDocument, linkRole, diffModel.getStatusesToIgnore());
+        if (documentsDiffParams.isSyncStructureEnabled()) {
+            // Moved-item surrogates are only relevant when structure is synced
+            pairedWorkItems = handleMovedItems(pairedWorkItems);
+        } else {
+            // Structure sync disabled: drop structural (added/deleted) pairs, keep only content changes of items present on both sides
+            pairedWorkItems = pairedWorkItems.stream()
+                    .filter(pair -> pair.getLeftWorkItem() != null && pair.getRightWorkItem() != null)
+                    .toList();
+        }
 
         // Refresh workItems cache for both documents
         Subject userSubject = RequestContextUtil.getUserSubject();

--- a/src/main/java/ch/sbb/polarion/extension/diff_tool/service/DiffService.java
+++ b/src/main/java/ch/sbb/polarion/extension/diff_tool/service/DiffService.java
@@ -120,8 +120,8 @@ public class DiffService {
         List<DocumentContentAnchorsPair> pairedDocumentContentAnchors = getPairedDocumentContentAnchors(leftDocument, rightDocument, pairedWorkItems);
 
         return DocumentsContentDiff.builder()
-                .leftDocument(Document.from(leftDocument).authorizedForMerge(polarionService.userAuthorizedForMerge(leftDocumentIdentifier.getProjectId())))
-                .rightDocument(Document.from(rightDocument).authorizedForMerge(polarionService.userAuthorizedForMerge(rightDocumentIdentifier.getProjectId())))
+                .leftDocument(Document.from(leftDocument, polarionService.userAuthorizedForMerge(leftDocumentIdentifier.getProjectId())))
+                .rightDocument(Document.from(rightDocument, polarionService.userAuthorizedForMerge(rightDocumentIdentifier.getProjectId())))
                 .pairedContentAnchors(pairedDocumentContentAnchors)
                 .build();
     }
@@ -193,8 +193,8 @@ public class DiffService {
         polarionService.getDocumentWorkItemsCache().cacheWorkItemsFromDocument(rightDocument, userSubject);
 
         return DocumentsDiff.builder()
-                .leftDocument(Document.from(leftDocument).authorizedForMerge(polarionService.userAuthorizedForMerge(leftDocumentIdentifier.getProjectId())))
-                .rightDocument(Document.from(rightDocument).authorizedForMerge(polarionService.userAuthorizedForMerge(rightDocumentIdentifier.getProjectId())))
+                .leftDocument(Document.from(leftDocument, polarionService.userAuthorizedForMerge(leftDocumentIdentifier.getProjectId())))
+                .rightDocument(Document.from(rightDocument, polarionService.userAuthorizedForMerge(rightDocumentIdentifier.getProjectId())))
                 .pairedWorkItems(pairedWorkItems)
                 .build();
     }
@@ -592,8 +592,8 @@ public class DiffService {
                 rightDocumentIdentifier.getName(), rightDocumentIdentifier.getRevision());
 
         return DocumentsFieldsDiff.builder()
-                .leftDocument(Document.from(leftDocument).authorizedForMerge(polarionService.userAuthorizedForMerge(leftDocumentIdentifier.getProjectId())))
-                .rightDocument(Document.from(rightDocument).authorizedForMerge(polarionService.userAuthorizedForMerge(rightDocumentIdentifier.getProjectId())))
+                .leftDocument(Document.from(leftDocument, polarionService.userAuthorizedForMerge(leftDocumentIdentifier.getProjectId())))
+                .rightDocument(Document.from(rightDocument, polarionService.userAuthorizedForMerge(rightDocumentIdentifier.getProjectId())))
                 .pairedFields(getFieldsDiff(leftDocument, rightDocument, compareEnumsById, compareOnlyMutualFields))
                 .build();
     }

--- a/src/main/java/ch/sbb/polarion/extension/diff_tool/service/MergeService.java
+++ b/src/main/java/ch/sbb/polarion/extension/diff_tool/service/MergeService.java
@@ -326,7 +326,7 @@ public class MergeService {
     @VisibleForTesting
     IWorkItem createItem(WorkItemsPair pair, ILinkRoleOpt linkRoleObj, WorkItemsMergeContext context) {
         if (context.getSourceWorkItem(pair) != null && context.getTargetWorkItem(pair) == null) {
-            IWorkItem source = getWorkItem(context.getSourceWorkItem(pair));
+            IWorkItem source = Objects.requireNonNull(getWorkItem(context.getSourceWorkItem(pair)));
             IWorkItem newWorkItem = polarionService.getTrackerProject(context.getTargetProject().getId()).createWorkItem(Objects.requireNonNull(source.getType()).getId());
             if (context.getLinkRoleDirection() == LinkRoleDirection.DIRECT) {
                 newWorkItem.addLinkedItem(source, linkRoleObj, null, false);
@@ -359,7 +359,7 @@ public class MergeService {
         // ignore cognitive complexity complaint
     void updateAndMoveItem(MergeWorkItemsPair pair, DocumentsMergeContext context) {
         IWorkItem source = getWorkItem(context.getSourceWorkItem(pair));
-        IWorkItem target = getWorkItem(context.getTargetWorkItem(pair));
+        IWorkItem target = Objects.requireNonNull(getWorkItem(context.getTargetWorkItem(pair)));
         boolean moveRequested = pair.getLeftWorkItem().getMovedOutlineNumber() != null || pair.getRightWorkItem().getMovedOutlineNumber() != null;
 
         if (!context.getTargetModule().getExternalWorkItems().contains(target)) {

--- a/src/test/java/ch/sbb/polarion/extension/diff_tool/rest/controller/DiffInternalControllerTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/diff_tool/rest/controller/DiffInternalControllerTest.java
@@ -67,13 +67,13 @@ class DiffInternalControllerTest {
 
     @Test
     void getDocumentsDiffThrowsWhenLeftDocumentMissing() {
-        DocumentsDiffParams params = new DocumentsDiffParams(null, mock(DocumentIdentifier.class), "role", null, null);
+        DocumentsDiffParams params = new DocumentsDiffParams(null, mock(DocumentIdentifier.class), "role", null, null, null);
         assertThrows(BadRequestException.class, () -> controller.getDocumentsDiff(params));
     }
 
     @Test
     void getDocumentsDiffThrowsWhenRightDocumentMissing() {
-        DocumentsDiffParams params = new DocumentsDiffParams(mock(DocumentIdentifier.class), null, "role", null, null);
+        DocumentsDiffParams params = new DocumentsDiffParams(mock(DocumentIdentifier.class), null, "role", null, null, null);
         assertThrows(BadRequestException.class, () -> controller.getDocumentsDiff(params));
     }
 
@@ -81,7 +81,7 @@ class DiffInternalControllerTest {
     void getDocumentsDiffThrowsWhenLinkRoleMissingForDifferentDocuments() {
         DocumentIdentifier left = DocumentIdentifier.builder().projectId("p").spaceId("s").name("a").build();
         DocumentIdentifier right = DocumentIdentifier.builder().projectId("p").spaceId("s").name("b").build();
-        DocumentsDiffParams params = new DocumentsDiffParams(left, right, null, null, null);
+        DocumentsDiffParams params = new DocumentsDiffParams(left, right, null, null, null, null);
         assertThrows(BadRequestException.class, () -> controller.getDocumentsDiff(params));
     }
 
@@ -89,10 +89,10 @@ class DiffInternalControllerTest {
     void getDocumentsDiffAllowsMissingLinkRoleWhenSameDocument() {
         DocumentIdentifier left = DocumentIdentifier.builder().projectId("p").spaceId("s").name("doc").revision("r1").build();
         DocumentIdentifier right = DocumentIdentifier.builder().projectId("p").spaceId("s").name("doc").revision("r2").build();
-        DocumentsDiffParams params = new DocumentsDiffParams(left, right, null, null, null);
+        DocumentsDiffParams params = new DocumentsDiffParams(left, right, null, null, null, null);
 
         DocumentsDiff expected = DocumentsDiff.builder().build();
-        when(diffService.getDocumentsDiff(any(), any(), any(), any(), any())).thenReturn(expected);
+        when(diffService.getDocumentsDiff(any())).thenReturn(expected);
 
         assertNotNull(controller.getDocumentsDiff(params));
     }
@@ -101,10 +101,10 @@ class DiffInternalControllerTest {
     void getDocumentsDiffPassesValidLinkRoleThrough() {
         DocumentIdentifier left = DocumentIdentifier.builder().projectId("pA").spaceId("s").name("doc").build();
         DocumentIdentifier right = DocumentIdentifier.builder().projectId("pB").spaceId("s").name("doc").build();
-        DocumentsDiffParams params = new DocumentsDiffParams(left, right, "relates-to", null, null);
+        DocumentsDiffParams params = new DocumentsDiffParams(left, right, "relates-to", null, null, null);
 
         DocumentsDiff expected = DocumentsDiff.builder().build();
-        when(diffService.getDocumentsDiff(any(), any(), any(), any(), any())).thenReturn(expected);
+        when(diffService.getDocumentsDiff(any())).thenReturn(expected);
 
         assertNotNull(controller.getDocumentsDiff(params));
     }

--- a/src/test/java/ch/sbb/polarion/extension/diff_tool/rest/model/diff/DocumentsDiffParamsTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/diff_tool/rest/model/diff/DocumentsDiffParamsTest.java
@@ -2,11 +2,34 @@ package ch.sbb.polarion.extension.diff_tool.rest.model.diff;
 
 import ch.sbb.polarion.extension.diff_tool.rest.model.DocumentIdentifier;
 import ch.sbb.polarion.extension.generic.settings.NamedSettings;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.SneakyThrows;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 class DocumentsDiffParamsTest {
+
+    @Test
+    @SneakyThrows
+    void testSyncStructureDeserializesFromJson() {
+        ObjectMapper mapper = new ObjectMapper();
+
+        // Explicit false must be honoured (regression guard: a @JsonIgnore accessor colliding with the
+        // "syncStructure" property name would make Jackson drop the incoming value)
+        DocumentsDiffParams disabled = mapper.readValue("{\"syncStructure\": false}", DocumentsDiffParams.class);
+        assertEquals(Boolean.FALSE, disabled.getSyncStructure());
+        assertFalse(disabled.isSyncStructureEnabled());
+
+        DocumentsDiffParams enabled = mapper.readValue("{\"syncStructure\": true}", DocumentsDiffParams.class);
+        assertEquals(Boolean.TRUE, enabled.getSyncStructure());
+        assertTrue(enabled.isSyncStructureEnabled());
+
+        // Omitted ⇒ defaults to enabled (backward compatibility)
+        DocumentsDiffParams omitted = mapper.readValue("{}", DocumentsDiffParams.class);
+        assertNull(omitted.getSyncStructure());
+        assertTrue(omitted.isSyncStructureEnabled());
+    }
 
     @Test
     void testNoArgsConstructor() {
@@ -31,7 +54,7 @@ class DocumentsDiffParamsTest {
                 .name("rightDoc")
                 .build();
 
-        DocumentsDiffParams params = new DocumentsDiffParams(leftDoc, rightDoc, "linkRole", "customConfig", "bucketId");
+        DocumentsDiffParams params = new DocumentsDiffParams(leftDoc, rightDoc, "linkRole", "customConfig", "bucketId", null);
 
         assertEquals(leftDoc, params.getLeftDocument());
         assertEquals(rightDoc, params.getRightDocument());

--- a/src/test/java/ch/sbb/polarion/extension/diff_tool/rest/model/diff/WorkItemFieldTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/diff_tool/rest/model/diff/WorkItemFieldTest.java
@@ -5,8 +5,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Set;
 import java.util.TreeSet;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 class WorkItemFieldTest {
     @Test
@@ -22,7 +21,7 @@ class WorkItemFieldTest {
         WorkItemField field1 = WorkItemField.builder().key("key1").name("Priority").wiTypeName("Requirement").build();
         WorkItemField field2 = WorkItemField.builder().key("key2").name("Priority").wiTypeName("Requirement").build();
 
-        assertTrue(field1.compareTo(field2) != 0);
+        assertNotEquals(0, field1.compareTo(field2));
         assertEquals("key1".compareTo("key2"), field1.compareTo(field2));
     }
 
@@ -33,7 +32,7 @@ class WorkItemFieldTest {
         WorkItemField typeCopy = WorkItemField.builder().key("custom").name("Custom Field").wiTypeName("Requirement").build();
 
         // wiTypeName still differentiates the two copies for ordering, but they remain distinct entries
-        assertTrue(globalCopy.compareTo(typeCopy) != 0);
+        assertNotEquals(0, globalCopy.compareTo(typeCopy));
     }
 
     @Test

--- a/src/test/java/ch/sbb/polarion/extension/diff_tool/service/DiffServiceTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/diff_tool/service/DiffServiceTest.java
@@ -942,9 +942,9 @@ class DiffServiceTest {
 
         DocumentIdentifier leftDocumentIdentifier = DocumentIdentifier.builder().projectId("project1").spaceId("space1").name("left").revision("rev1").build();
         DocumentIdentifier rightDocumentIdentifier = DocumentIdentifier.builder().projectId("project1").spaceId("space1").name("right").revision("rev1").build();
+        DocumentsDiffParams params = new DocumentsDiffParams(leftDocumentIdentifier, rightDocumentIdentifier, "invalid-role", null, null, null);
 
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
-                diffService.getDocumentsDiff(new DocumentsDiffParams(leftDocumentIdentifier, rightDocumentIdentifier, "invalid-role", null, null, null)));
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> diffService.getDocumentsDiff(params));
 
         assertTrue(exception.getMessage().contains("invalid-role"));
     }
@@ -993,6 +993,49 @@ class DiffServiceTest {
         }
         // No link role lookup must happen for same-document compare with empty linkRoleId.
         verify(polarionService, never()).getLinkRoleById(anyString(), any());
+    }
+
+    @Test
+    void testGetDocumentsDiffWithSyncStructureDisabledKeepsOnlyItemsPresentOnBothSides() {
+        IModule document = mockSameDocumentForDiff();
+
+        when(polarionService.getDocumentWithFilledRevision("project1", "space1", "doc", "rev1")).thenReturn(document);
+        when(polarionService.getDocumentWithFilledRevision("project1", "space1", "doc", "rev2")).thenReturn(document);
+
+        // Mix of a content-only pair (present on both sides), a deleted item (left only) and an added item (right only).
+        WorkItemsPair contentPair = createWorkItemsPair("AA-1", "AA-2");
+        WorkItemsPair deletedPair = WorkItemsPair.builder().leftWorkItem(WorkItem.builder().id("AA-3").build()).build();
+        WorkItemsPair addedPair = WorkItemsPair.builder().rightWorkItem(WorkItem.builder().id("AA-4").build()).build();
+        when(polarionService.getPairedWorkItems(eq(document), eq(document), isNull(), anyList()))
+                .thenReturn(new ArrayList<>(List.of(contentPair, deletedPair, addedPair)));
+        when(polarionService.getDocumentWorkItemsCache()).thenReturn(mock(ch.sbb.polarion.extension.diff_tool.util.DocumentWorkItemsCache.class));
+
+        DocumentIdentifier leftDocumentIdentifier = DocumentIdentifier.builder().projectId("project1").spaceId("space1").name("doc").revision("rev1").build();
+        DocumentIdentifier rightDocumentIdentifier = DocumentIdentifier.builder().projectId("project1").spaceId("space1").name("doc").revision("rev2").build();
+
+        org.springframework.web.context.request.ServletRequestAttributes attrs =
+                mock(org.springframework.web.context.request.ServletRequestAttributes.class);
+        when(attrs.getRequest()).thenReturn(mock(javax.servlet.http.HttpServletRequest.class));
+        org.springframework.web.context.request.RequestContextHolder.setRequestAttributes(attrs);
+        try (org.mockito.MockedStatic<ch.sbb.polarion.extension.diff_tool.util.DiffModelCachedResource> mockedDiffModel =
+                     mockStatic(ch.sbb.polarion.extension.diff_tool.util.DiffModelCachedResource.class)) {
+            mockedDiffModel.when(() -> ch.sbb.polarion.extension.diff_tool.util.DiffModelCachedResource.get(any(), any(), any()))
+                    .thenReturn(ch.sbb.polarion.extension.diff_tool.rest.model.settings.DiffModel.builder().build());
+
+            DocumentsDiffParams params = new DocumentsDiffParams(leftDocumentIdentifier, rightDocumentIdentifier, null, null, null, false);
+            var result = diffService.getDocumentsDiff(params);
+
+            assertNotNull(result);
+            // Structural (added / deleted) pairs are dropped, only the pair present on both sides remains.
+            assertEquals(1, result.getPairedWorkItems().size());
+            WorkItemsPair survivingPair = new ArrayList<>(result.getPairedWorkItems()).get(0);
+            assertNotNull(survivingPair.getLeftWorkItem());
+            assertNotNull(survivingPair.getRightWorkItem());
+            assertEquals("AA-1", survivingPair.getLeftWorkItem().getId());
+            assertEquals("AA-2", survivingPair.getRightWorkItem().getId());
+        } finally {
+            org.springframework.web.context.request.RequestContextHolder.resetRequestAttributes();
+        }
     }
 
     @Test

--- a/src/test/java/ch/sbb/polarion/extension/diff_tool/service/DiffServiceTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/diff_tool/service/DiffServiceTest.java
@@ -7,6 +7,7 @@ import ch.sbb.polarion.extension.diff_tool.rest.model.diff.DocumentContentAnchor
 import ch.sbb.polarion.extension.diff_tool.rest.model.diff.DocumentContentAnchorsPair;
 import ch.sbb.polarion.extension.diff_tool.rest.model.diff.DocumentsCollection;
 import ch.sbb.polarion.extension.diff_tool.rest.model.diff.DocumentsContentDiff;
+import ch.sbb.polarion.extension.diff_tool.rest.model.diff.DocumentsDiffParams;
 import ch.sbb.polarion.extension.diff_tool.rest.model.diff.DocumentsFieldsDiff;
 import ch.sbb.polarion.extension.diff_tool.rest.model.diff.DocumentsFieldsPair;
 import ch.sbb.polarion.extension.diff_tool.rest.model.diff.MergeMoveDirection;
@@ -943,7 +944,7 @@ class DiffServiceTest {
         DocumentIdentifier rightDocumentIdentifier = DocumentIdentifier.builder().projectId("project1").spaceId("space1").name("right").revision("rev1").build();
 
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
-                diffService.getDocumentsDiff(leftDocumentIdentifier, rightDocumentIdentifier, "invalid-role", null, null));
+                diffService.getDocumentsDiff(new DocumentsDiffParams(leftDocumentIdentifier, rightDocumentIdentifier, "invalid-role", null, null, null)));
 
         assertTrue(exception.getMessage().contains("invalid-role"));
     }
@@ -958,10 +959,10 @@ class DiffServiceTest {
         DocumentIdentifier leftDocumentIdentifier = DocumentIdentifier.builder().projectId("project1").spaceId("space1").name("left").revision("rev1").build();
         DocumentIdentifier rightDocumentIdentifier = DocumentIdentifier.builder().projectId("project1").spaceId("space1").name("right").revision("rev1").build();
 
-        assertThrows(IllegalArgumentException.class, () ->
-                diffService.getDocumentsDiff(leftDocumentIdentifier, rightDocumentIdentifier, null, null, null));
-        assertThrows(IllegalArgumentException.class, () ->
-                diffService.getDocumentsDiff(leftDocumentIdentifier, rightDocumentIdentifier, "", null, null));
+        DocumentsDiffParams nullRoleParams = new DocumentsDiffParams(leftDocumentIdentifier, rightDocumentIdentifier, null, null, null, null);
+        DocumentsDiffParams emptyRoleParams = new DocumentsDiffParams(leftDocumentIdentifier, rightDocumentIdentifier, "", null, null, null);
+        assertThrows(IllegalArgumentException.class, () -> diffService.getDocumentsDiff(nullRoleParams));
+        assertThrows(IllegalArgumentException.class, () -> diffService.getDocumentsDiff(emptyRoleParams));
         verify(polarionService, never()).getLinkRoleById(anyString(), any());
     }
 
@@ -985,8 +986,8 @@ class DiffServiceTest {
                      mockStatic(ch.sbb.polarion.extension.diff_tool.util.DiffModelCachedResource.class)) {
             mockedDiffModel.when(() -> ch.sbb.polarion.extension.diff_tool.util.DiffModelCachedResource.get(any(), any(), any()))
                     .thenReturn(ch.sbb.polarion.extension.diff_tool.rest.model.settings.DiffModel.builder().build());
-            assertNotNull(diffService.getDocumentsDiff(leftDocumentIdentifier, rightDocumentIdentifier, null, null, null));
-            assertNotNull(diffService.getDocumentsDiff(leftDocumentIdentifier, rightDocumentIdentifier, "", null, null));
+            assertNotNull(diffService.getDocumentsDiff(new DocumentsDiffParams(leftDocumentIdentifier, rightDocumentIdentifier, null, null, null, null)));
+            assertNotNull(diffService.getDocumentsDiff(new DocumentsDiffParams(leftDocumentIdentifier, rightDocumentIdentifier, "", null, null, null)));
         } finally {
             org.springframework.web.context.request.RequestContextHolder.resetRequestAttributes();
         }
@@ -1004,7 +1005,8 @@ class DiffServiceTest {
         DocumentIdentifier left = DocumentIdentifier.builder().projectId("projectA").spaceId("space1").name("doc").build();
         DocumentIdentifier right = DocumentIdentifier.builder().projectId("projectB").spaceId("space1").name("doc").build();
 
-        assertThrows(IllegalArgumentException.class, () -> diffService.getDocumentsDiff(left, right, null, null, null));
+        DocumentsDiffParams params = new DocumentsDiffParams(left, right, null, null, null, null);
+        assertThrows(IllegalArgumentException.class, () -> diffService.getDocumentsDiff(params));
     }
 
     @Test
@@ -1018,7 +1020,8 @@ class DiffServiceTest {
         DocumentIdentifier right = DocumentIdentifier.builder().projectId("project1").spaceId("space2").name("doc").build();
 
         // Same project + name, but different space ⇒ documents differ ⇒ linkRole still required.
-        assertThrows(IllegalArgumentException.class, () -> diffService.getDocumentsDiff(left, right, null, null, null));
+        DocumentsDiffParams params = new DocumentsDiffParams(left, right, null, null, null, null);
+        assertThrows(IllegalArgumentException.class, () -> diffService.getDocumentsDiff(params));
     }
 
     @Test
@@ -1032,7 +1035,8 @@ class DiffServiceTest {
         DocumentIdentifier right = DocumentIdentifier.builder().projectId("project1").spaceId("space1").name("right").build();
 
         // Same project + space, but different name ⇒ documents differ ⇒ linkRole still required.
-        assertThrows(IllegalArgumentException.class, () -> diffService.getDocumentsDiff(left, right, null, null, null));
+        DocumentsDiffParams params = new DocumentsDiffParams(left, right, null, null, null, null);
+        assertThrows(IllegalArgumentException.class, () -> diffService.getDocumentsDiff(params));
     }
 
     @Test

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -676,9 +676,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -694,9 +691,6 @@
       "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -714,9 +708,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -732,9 +723,6 @@
       "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -752,9 +740,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -770,9 +755,6 @@
       "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -790,9 +772,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -809,9 +788,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -827,9 +803,6 @@
       "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -853,9 +826,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -877,9 +847,6 @@
       "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -903,9 +870,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -927,9 +891,6 @@
       "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -953,9 +914,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -978,9 +936,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1002,9 +957,6 @@
       "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1304,9 +1256,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1322,9 +1271,6 @@
       "integrity": "sha512-qyogG9QtBzWxgJfeGBvOEHI3851gTfCF3wLZ5RDLTBJGAmE9p1qDwKCOdrBrvBzRvYDT+gUDp72pzlSEfAXgNA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1342,9 +1288,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1360,9 +1303,6 @@
       "integrity": "sha512-srvian89JahFLw1YLBEuhvPJ0DO5lpUeJQMXy4xYo7g628ZlNgXdNkqoxSAv9OYrBfByh6vxISMwW/mRbzCY+g==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1894,9 +1834,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1911,9 +1848,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1928,9 +1862,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1945,9 +1876,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1962,9 +1890,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1979,9 +1904,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1996,9 +1918,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2013,9 +1932,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2030,9 +1946,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2047,9 +1960,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3809,6 +3719,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/ui/src/components/ControlPane.js
+++ b/ui/src/components/ControlPane.js
@@ -216,6 +216,15 @@ export default function ControlPane({diff_type}) {
                 </label>
               </div>
           }
+          {(diff_type === DiffTypes.DOCUMENTS_DIFF || diff_type === DiffTypes.COLLECTIONS_DIFF) &&
+              <div className="form-check">
+                <input className="form-check-input" type="checkbox" checked={context.state.syncStructure} id="sync-structure"
+                       onChange={() => context.state.setSyncStructure(!context.state.syncStructure)}/>
+                <label className="form-check-label" htmlFor="sync-structure" title="When unchecked, moved, added and removed items are hidden and only content changes of items present in both documents are compared and merged.">
+                  Sync structure
+                </label>
+              </div>
+          }
           {diff_type !== DiffTypes.DOCUMENTS_FIELDS_DIFF && diff_type !== DiffTypes.DOCUMENTS_CONTENT_DIFF &&
               <div className="form-check">
                 <input className="form-check-input" type="checkbox" value="" id="counterparts-differ"

--- a/ui/src/components/documents/DocumentsContentDiff.js
+++ b/ui/src/components/documents/DocumentsContentDiff.js
@@ -49,8 +49,16 @@ export default function DocumentsContentDiff({ enclosingCollections }) {
       return;
     }
 
+    let ignore = false; // guard against a superseded request overwriting docsData with stale results
     diffService.sendDocumentsContentDiffRequest(searchParams, uuidv4(), loadingContext)
-        .then((data) => setDocsData(data));
+        .then((data) => {
+          if (!ignore) {
+            setDocsData(data);
+          }
+        });
+    return () => {
+      ignore = true;
+    };
   }, [searchParams]);
 
   useEffect(() => {

--- a/ui/src/components/documents/DocumentsDiff.js
+++ b/ui/src/components/documents/DocumentsDiff.js
@@ -70,9 +70,17 @@ export default function DocumentsDiff({ enclosingCollections }) {
     const cacheId = uuidv4();
     setConfigCacheId(cacheId);
 
-    diffService.sendDocumentsDiffRequest(searchParams, cacheId, loadingContext)
-        .then((data) => setDocsData(data));
-  }, [searchParams]);
+    let ignore = false; // guard against a superseded request overwriting docsData with stale results
+    diffService.sendDocumentsDiffRequest(searchParams, cacheId, loadingContext, context.state.syncStructure)
+        .then((data) => {
+          if (!ignore) {
+            setDocsData(data);
+          }
+        });
+    return () => {
+      ignore = true;
+    };
+  }, [searchParams, context.state.syncStructure]);
 
   useEffect(() => {
     if (docsData && docsData.pairedWorkItems && docsData.pairedWorkItems.length > 0) {

--- a/ui/src/components/documents/DocumentsFieldsDiff.js
+++ b/ui/src/components/documents/DocumentsFieldsDiff.js
@@ -1,4 +1,4 @@
-import {useContext, useEffect, useState} from "react";
+import {useContext, useEffect, useRef, useState} from "react";
 import {useSearchParams} from "next/navigation";
 import AppContext from "../AppContext";
 import AppAlert from "@/components/AppAlert";
@@ -42,6 +42,7 @@ export default function DocumentsFieldsDiff({ enclosingCollections }) {
   const [mergeDeniedWarning, setMergeDeniedWarning] = useState(false);  // means that merge operation was denied because displayed state of documents is not last one
   const [mergeNotAuthorizedWarning, setMergeNotAuthorizedWarning] = useState(false);  // means that merge to target document is not authorized for current user
   const [mergeReportModalVisible, setMergeReportModalVisible] = useState(false);
+  const latestRequestRef = useRef(0);
 
   useEffect(() => {
     const missingParams = REQUIRED_PARAMS.filter(param => !searchParams.get(param));
@@ -55,9 +56,14 @@ export default function DocumentsFieldsDiff({ enclosingCollections }) {
   }, [searchParams]);
 
   const loadDiff = () => {
+    // Guard against a superseded request overwriting state with stale results (deps/settings can change while in flight)
+    const requestId = ++latestRequestRef.current;
     mergingContext.resetRegistry();
     diffService.sendDocumentsFieldsDiffRequest(searchParams, context.state.compareEnumsById, context.state.compareOnlyMutualFields, loadingContext)
         .then((data)=> {
+              if (requestId !== latestRequestRef.current) {
+                return;
+              }
               setFieldsData(data);
               let diffs = data.pairedFields.filter(fieldDiff => fieldDiff.leftField.htmlDiff && fieldDiff.rightField.htmlDiff).map((fieldDiff, index) => {
                 mergingContext.setPairSelected(index, fieldDiff.leftField.id, false);

--- a/ui/src/components/documents/workitems/WorkItemsPairDiff.js
+++ b/ui/src/components/documents/workitems/WorkItemsPairDiff.js
@@ -1,5 +1,5 @@
 import DiffContent from "@/components/diff/DiffContent";
-import {useContext, useEffect, useState} from "react";
+import {useContext, useEffect, useRef, useState} from "react";
 import {WorkItemHeader, LEFT, RIGHT} from "@/components/WorkItemHeader";
 import FloatingButton from "@/components/FloatingButton";
 import {faChevronDown, faChevronUp, faEquals, faQuestion} from "@fortawesome/free-solid-svg-icons";
@@ -37,6 +37,7 @@ export default function WorkItemsPairDiff({ leftDocument, rightDocument, workIte
   const [selected, setSelected] = useState(mergingContext.isIndexSelected(currentIndex));
   const [pairSelectionTrigger, setPairSelectionTrigger] = useState(0);
   const [childrenSelectionModalVisible, setChildrenSelectionModalVisible] = useState(false);
+  const latestRequestRef = useRef(0); // guards against a superseded (or retried) request overwriting diffData with stale results
 
   useEffect(() => {
     if (onHold && loadingContext.pairLoadingAllowed(currentIndex)) {
@@ -111,7 +112,7 @@ export default function WorkItemsPairDiff({ leftDocument, rightDocument, workIte
         body.rightWorkItem.revision = workItemsPair.rightWorkItem.revision;
       }
     }
-    requestDiff(body, 0);
+    requestDiff(body, 0, ++latestRequestRef.current);
   }, [onHold]);
 
   useEffect(() => {
@@ -198,7 +199,7 @@ export default function WorkItemsPairDiff({ leftDocument, rightDocument, workIte
     return reportEntry && reportEntry.workItemsPair;
   };
 
-  const requestDiff = (body, triesCount) => {
+  const requestDiff = (body, triesCount, requestId) => {
     setLoading(true);
     setDataLoadedFired(false);
     remote.sendRequest({
@@ -212,7 +213,9 @@ export default function WorkItemsPairDiff({ leftDocument, rightDocument, workIte
       } else {
         if (CODES_TO_RETRY.includes(response.status) && triesCount < 3) {
           setTimeout(() => {
-            requestDiff(body, triesCount + 1);
+            if (requestId === latestRequestRef.current) { // do not retry a superseded request
+              requestDiff(body, triesCount + 1, requestId);
+            }
           }, triesCount * 2000 + 1000);
           throw Promise.resolve(RETRY_MARKER); // Marker for later code that we are still trying to obtain diff from server
         } else {
@@ -220,6 +223,9 @@ export default function WorkItemsPairDiff({ leftDocument, rightDocument, workIte
         }
       }
     }).then(data =>  {
+      if (requestId !== latestRequestRef.current) {
+        return; // a newer request has superseded this one, ignore its (stale) result
+      }
       // ----- We need to reload title/outlineNumber information in case if they were modified by merge
       if (data.leftWorkItem) {
         workItemsPair.leftWorkItem.title = data.leftWorkItem.title;
@@ -234,6 +240,9 @@ export default function WorkItemsPairDiff({ leftDocument, rightDocument, workIte
       setLoading(false);
     }).catch(errorResponse => {
       Promise.resolve(errorResponse).then((error) => {
+        if (requestId !== latestRequestRef.current) {
+          return; // superseded request, ignore its error too
+        }
         if (RETRY_MARKER !== error) {
           setError(error && error.message ? error.message : "Error occurred loading diff data");
           setLoading(false);

--- a/ui/src/components/workitems/WorkItemsDiff.js
+++ b/ui/src/components/workitems/WorkItemsDiff.js
@@ -66,11 +66,18 @@ export default function WorkItemsDiff() {
 
     setConfigCacheId(uuidv4());
 
+    let ignore = false; // guard against a superseded request overwriting workItemsData with stale results
     diffService.sendFindWorkItemsPairsRequest(searchParams, loadingContext)
         .then((data) => {
+          if (ignore) {
+            return;
+          }
           setWorkItemsData(data);
           setRedundancyModalVisible(data.leftWorkItemIdsWithRedundancy && data.leftWorkItemIdsWithRedundancy.length > 0);
         });
+    return () => {
+      ignore = true;
+    };
   }, [searchParams]);
 
   useEffect(() => {

--- a/ui/src/components/workitems/WorkItemsPairDiff.js
+++ b/ui/src/components/workitems/WorkItemsPairDiff.js
@@ -1,6 +1,6 @@
 import PairMergeTicker from "@/components/merge/PairMergeTicker";
 import {LEFT, RIGHT, WorkItemHeader} from "@/components/WorkItemHeader";
-import {useContext, useEffect, useState} from "react";
+import {useContext, useEffect, useRef, useState} from "react";
 import useImageUtils from "@/utils/useImageUtils";
 import DiffContent from "@/components/diff/DiffContent";
 import useRemote from "@/services/useRemote";
@@ -28,6 +28,7 @@ export default function WorkItemsPairDiff({ workItemsPair, leftProject, rightPro
   const [dataLoadedFired, setDataLoadedFired] = useState(false);
   const [selected, setSelected] = useState(mergingContext.isIndexSelected(currentIndex));
   const [pairSelectionTrigger, setPairSelectionTrigger] = useState(0);
+  const latestRequestRef = useRef(0); // guards against a superseded (or retried) request overwriting diffData with stale results
 
   useEffect(() => {
     if (onHold && loadingContext.pairLoadingAllowed(currentIndex)) {
@@ -84,7 +85,7 @@ export default function WorkItemsPairDiff({ workItemsPair, leftProject, rightPro
         }
       }
     }
-    requestDiff(body, 0);
+    requestDiff(body, 0, ++latestRequestRef.current);
   }, [onHold]);
 
   useEffect(() => {
@@ -150,7 +151,7 @@ export default function WorkItemsPairDiff({ workItemsPair, leftProject, rightPro
     setExpanded(!expanded);
   };
 
-  const requestDiff = (body, triesCount) => {
+  const requestDiff = (body, triesCount, requestId) => {
     setLoading(true);
     setDataLoadedFired(false);
     remote.sendRequest({
@@ -164,7 +165,9 @@ export default function WorkItemsPairDiff({ workItemsPair, leftProject, rightPro
       } else {
         if (CODES_TO_RETRY.includes(response.status) && triesCount < 3) {
           setTimeout(() => {
-            requestDiff(body, triesCount + 1);
+            if (requestId === latestRequestRef.current) { // do not retry a superseded request
+              requestDiff(body, triesCount + 1, requestId);
+            }
           }, triesCount * 2000 + 1000);
           throw Promise.resolve(RETRY_MARKER); // Marker for later code that we are still trying to obtain diff from server
         } else {
@@ -172,6 +175,9 @@ export default function WorkItemsPairDiff({ workItemsPair, leftProject, rightPro
         }
       }
     }).then(data =>  {
+      if (requestId !== latestRequestRef.current) {
+        return; // a newer request has superseded this one, ignore its (stale) result
+      }
       // ----- We need to reload title/outlineNumber information in case if they were modified by merge
       if (data.leftWorkItem) {
         workItemsPair.leftWorkItem.title = data.leftWorkItem.title;
@@ -184,6 +190,9 @@ export default function WorkItemsPairDiff({ workItemsPair, leftProject, rightPro
       setLoading(false);
     }).catch(errorResponse => {
       Promise.resolve(errorResponse).then((error) => {
+        if (requestId !== latestRequestRef.current) {
+          return; // superseded request, ignore its error too
+        }
         if (RETRY_MARKER !== error) {
           setError(error && error.message ? error.message : "Error occurred loading diff data");
           setLoading(false);

--- a/ui/src/services/useDiffService.js
+++ b/ui/src/services/useDiffService.js
@@ -4,7 +4,7 @@ import {CONTENT_ABOVE, CONTENT_BELOW} from "@/components/documents/ContentAnchor
 export default function useDiffService() {
   const remote = useRemote();
 
-  const sendDocumentsDiffRequest = (searchParams, configCacheId, loadingContext) => {
+  const sendDocumentsDiffRequest = (searchParams, configCacheId, loadingContext, syncStructure) => {
     const leftDocument = getDocumentFromSearchParams(searchParams, 'source');
     const rightDocument = getDocumentFromSearchParams(searchParams, 'target');
 
@@ -19,7 +19,8 @@ export default function useDiffService() {
           rightDocument: rightDocument,
           linkRole: searchParams.get('linkRole'),
           configName: searchParams.get('config'),
-          configCacheBucketId: configCacheId
+          configCacheBucketId: configCacheId,
+          syncStructure: syncStructure
         }),
         contentType: "application/json"
       })

--- a/ui/src/useAppContext.js
+++ b/ui/src/useAppContext.js
@@ -6,6 +6,7 @@ export function useAppContext(){
   const [controlPaneExpanded, setControlPaneExpanded] = useState(false);
   const [pairedDocuments, setPairedDocuments] = useState([]);
   const [showOutlineNumbersDiff, setShowOutlineNumbersDiff] = useState(false);
+  const [syncStructure, setSyncStructure] = useState(true);
   const [counterpartWorkItemsDiffer, setCounterpartWorkItemsDiffer] = useState(false);
   const [compareOnlyMutualFields, setCompareOnlyMutualFields] = useState(true);
   const [compareEnumsById, setCompareEnumsById] = useState(false);
@@ -73,6 +74,8 @@ export function useAppContext(){
     setPairedDocuments,
     showOutlineNumbersDiff,
     setShowOutlineNumbersDiff,
+    syncStructure,
+    setSyncStructure,
     counterpartWorkItemsDiffer,
     setCounterpartWorkItemsDiffer,
     compareOnlyMutualFields,


### PR DESCRIPTION
Make structure sync optional

Closes https://github.com/SchweizerischeBundesbahnen/ch.sbb.polarion.extension.diff-tool/issues/563

### Proposed changes

The Diff-Tool syncs data (field/content values) and structure (moved/reordered items, and items added/removed) at the same time. The structural operations — moving items in the document tree and creating/deleting items — sometimes fail, and in many cases structural changes are not important. This makes structure sync optional via a sidebar option.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
