### PR TITLE
chore: inherit swagger plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,6 @@
 
         <awaitility.version>4.3.0</awaitility.version>
 
-        <swagger-maven-plugin.version>2.2.22</swagger-maven-plugin.version>
 
         <!--suppress UnresolvedMavenProperty -->
         <markdown2html-maven-plugin.failOnError>${env.MARKDOWN2HTML_MAVEN_PLUGIN_FAIL_ON_ERROR}</markdown2html-maven-plugin.failOnError>


### PR DESCRIPTION
### Proposed changes

`swagger-maven-plugin-jakarta` is declared without a `<version>`, so it takes the one from the generic parent's `pluginManagement`. A local property of the same name overrode that value in the effective POM and pinned the build to **2.2.22** while the parent had long moved to **2.2.52** - and renovate never tracked it, because the property carries no version declaration of its own to attach an update to (it does not appear in this repo's Dependency Dashboard at all). Removing the property lets the version come from the parent, like everywhere else in the family.

The generated `docs/openapi.json` comes out **unchanged** - the two plugin versions produce the same specification.

Verified: full `mvn install` green.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation
