### PR TITLE
chore: family maintenance sweep

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -23,7 +23,6 @@ jobs:
     env:
       IO_JFROG_SBB_POLARION_TOKEN: ${{ secrets.IO_JFROG_SBB_POLARION_TOKEN }}
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      MARKDOWN2HTML_MAVEN_PLUGIN_FAIL_ON_ERROR: true
       GITHUB_TOKEN: ${{ github.token }}  # Providing this prevents reaching the GitHub request limits
     steps:
       - name: 📄 Checkout the repository

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,6 +64,14 @@ repos:
         entry: \bDEV-\d{1,6}\b
         language: pygrep
         types: [text]
+      # Dockerized Vitest (behavior + visual regression) with the 80% coverage gate. Heavy
+      # (~30-60s+, needs Docker running); gated on ui/ source changes.
+      - id: ui-test-coverage-docker
+        name: UI Vitest + coverage gate (Docker)
+        entry: npm --prefix ui run test:coverage:docker
+        language: system
+        pass_filenames: false
+        files: ^ui/.*\.(ts|tsx|css)$
   - repo: https://github.com/zricethezav/gitleaks
     rev: v8.30.1
     hooks:

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -110,6 +110,24 @@ mvn verify
 
 The reports will be available in `target/site/jacoco`.
 
+### UI Test Flags
+
+The `ui/` Vitest suite runs in the `test` phase alongside the Java tests. By default it runs the full suite (behavior + visual regression) inside the pinned Playwright Docker image so the screenshots match the committed references. These `-D` flags adjust that:
+
+| Flag | Effect |
+| --- | --- |
+| `-DskipJsTests` | Skip all UI tests (Java tests still run). Use on a host without Docker. |
+| `-DjsTestsNoDocker` | Run the tests natively (`npm run test:coverage:full`) instead of the Docker image. Needs the Playwright browser on the host (see the install flags below). |
+| `-DinstallPlaywright` | Install the Chromium browser plus its OS libraries (the with-deps variant) before the tests. Needs a Debian/Ubuntu host with `apt-get` and root/sudo. |
+| `-DinstallPlaywrightNoDeps` | Install the Chromium browser binary only. For hosts without `apt-get`/root; the host must already provide Chromium's system libraries. |
+| `-DskipVisualJsTests` | Exclude the pixel-based visual-regression tests (`*.visual.test.tsx`), which only reproduce inside the Docker image. Only effective together with `-DjsTestsNoDocker`. |
+
+Docker-less run of the behavior tests:
+
+```bash
+mvn clean install -DjsTestsNoDocker -DinstallPlaywrightNoDeps -DskipVisualJsTests
+```
+
 ## Debugging
 
 ### Remote Debugging

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -112,7 +112,7 @@ The reports will be available in `target/site/jacoco`.
 
 ### UI Test Flags
 
-The `ui/` Vitest suite runs in the `test` phase alongside the Java tests. By default it runs the full suite (behavior + visual regression) inside the pinned Playwright Docker image so the screenshots match the committed references. These `-D` flags adjust that:
+The `ui/` Vitest suite runs in the `test` phase alongside the Java tests. By default it runs the full suite (behavior + visual regression) inside the pinned Playwright Docker image so the screenshots match the committed references. The Playwright end-to-end suite in `ui/e2e` runs in the same phase and is this repository's own - a plain `mvn install` exercises the diff/merge viewer end to end. These `-D` flags adjust that:
 
 | Flag | Effect |
 | --- | --- |
@@ -121,12 +121,17 @@ The `ui/` Vitest suite runs in the `test` phase alongside the Java tests. By def
 | `-DinstallPlaywright` | Install the Chromium browser plus its OS libraries (the with-deps variant) before the tests. Needs a Debian/Ubuntu host with `apt-get` and root/sudo. |
 | `-DinstallPlaywrightNoDeps` | Install the Chromium browser binary only. For hosts without `apt-get`/root; the host must already provide Chromium's system libraries. |
 | `-DskipVisualJsTests` | Exclude the pixel-based visual-regression tests (`*.visual.test.tsx`), which only reproduce inside the Docker image. Only effective together with `-DjsTestsNoDocker`. |
+| `-DskipJsE2eTests` | Skip the Playwright end-to-end suite in `ui/e2e`, keeping Vitest and its coverage gate. It runs by default and needs the browsers installed; CI passes this flag. |
 
 Docker-less run of the behavior tests:
 
 ```bash
-mvn clean install -DjsTestsNoDocker -DinstallPlaywrightNoDeps -DskipVisualJsTests
+mvn clean install -DjsTestsNoDocker -DinstallPlaywrightNoDeps -DskipVisualJsTests -DskipJsE2eTests=true
 ```
+
+`-DskipJsE2eTests=true` belongs in that line: without it the build still runs `npx playwright install`
+and the end-to-end suite, which downloads the full browser set and then needs the very OS libraries
+`-DinstallPlaywrightNoDeps` exists to avoid.
 
 ## Debugging
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -450,6 +450,27 @@
         ]
       }
     },
+    "/api/disclaimer": {
+      "get": {
+        "operationId": "getDisclaimer",
+        "responses": {
+          "default": {
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "HTML help article"
+          }
+        },
+        "summary": "Returns the build-generated DISCLAIMER help article shown on the Usage Disclaimer page",
+        "tags": [
+          "Extension Information"
+        ]
+      }
+    },
     "/api/extension/info": {
       "get": {
         "operationId": "getExtensionInfo",

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>ch.sbb.polarion.extensions</groupId>
         <artifactId>ch.sbb.polarion.extension.generic</artifactId>
-        <version>15.10.1</version>
+        <version>15.11.0</version>
     </parent>
 
     <artifactId>ch.sbb.polarion.extension.diff-tool</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -329,6 +329,8 @@
                 <artifactId>swagger-maven-plugin-jakarta</artifactId>
                 <configuration>
                     <outputFormat>JSON</outputFormat>
+                    <!-- Stable ordering, so a rebuild does not reshuffle docs/openapi.json. -->
+                    <sortOutput>true</sortOutput>
                     <resourcePackages>
                         <package>ch.sbb.polarion.extension.generic.rest.controller.info</package>
                         <package>ch.sbb.polarion.extension.generic.rest.controller.settings</package>

--- a/pom.xml
+++ b/pom.xml
@@ -332,7 +332,6 @@
                 <configuration>
                     <outputFormat>JSON</outputFormat>
                     <!-- Stable ordering, so a rebuild does not reshuffle docs/openapi.json. -->
-                    <sortOutput>true</sortOutput>
                     <resourcePackages>
                         <package>ch.sbb.polarion.extension.generic.rest.controller.info</package>
                         <package>ch.sbb.polarion.extension.generic.rest.controller.settings</package>

--- a/pom.xml
+++ b/pom.xml
@@ -74,8 +74,10 @@
         <awaitility.version>4.3.0</awaitility.version>
 
 
-        <!--suppress UnresolvedMavenProperty -->
-        <markdown2html-maven-plugin.failOnError>${env.MARKDOWN2HTML_MAVEN_PLUGIN_FAIL_ON_ERROR}</markdown2html-maven-plugin.failOnError>
+        <!-- A broken README.md -> about.html conversion fails the build instead of shipping an
+             empty About page. markdown2html renders locally since 1.7.x - no GitHub API, no token -
+             so the same setting is right in CI, in a deploy job and on a developer machine. -->
+        <markdown2html-maven-plugin.failOnError>true</markdown2html-maven-plugin.failOnError>
 
         <!-- Most of the UI build - node/npm, `npm ci`, `npm run build`, the dockerized Vitest run with
              its coverage gate in the `test` phase, and the copy into webapp/diff-tool-app - is inherited

--- a/src/test/java/ch/sbb/polarion/extension/diff_tool/DiffToolAppUIServletTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/diff_tool/DiffToolAppUIServletTest.java
@@ -1,0 +1,16 @@
+package ch.sbb.polarion.extension.diff_tool;
+
+import ch.sbb.polarion.extension.generic.GenericUiServlet;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DiffToolAppUIServletTest {
+
+    @Test
+    void instantiatesAsGenericUiServlet() {
+        DiffToolAppUIServlet servlet = new DiffToolAppUIServlet();
+
+        assertThat(servlet).isInstanceOf(GenericUiServlet.class);
+    }
+}

--- a/src/test/java/ch/sbb/polarion/extension/diff_tool/DiffToolAppUIServletTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/diff_tool/DiffToolAppUIServletTest.java
@@ -63,7 +63,6 @@ class DiffToolAppUIServletTest {
         // The extension's other context: a request meant for it must not be served from this app.
         HttpServletRequest request = requestFor("/polarion/diff-tool/ui/app/index.html");
 
-        // Only the call under test may throw here, so the assertion cannot pass for the wrong reason.
         IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
                 () -> servlet.service(request, response));
 

--- a/src/test/java/ch/sbb/polarion/extension/diff_tool/DiffToolAppUIServletTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/diff_tool/DiffToolAppUIServletTest.java
@@ -61,8 +61,11 @@ class DiffToolAppUIServletTest {
     @Test
     void rejectsAnotherWebappContext() {
         // The extension's other context: a request meant for it must not be served from this app.
+        HttpServletRequest request = requestFor("/polarion/diff-tool/ui/app/index.html");
+
+        // Only the call under test may throw here, so the assertion cannot pass for the wrong reason.
         IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
-                () -> servlet.service(requestFor("/polarion/diff-tool/ui/app/index.html"), response));
+                () -> servlet.service(request, response));
 
         assertEquals("Unsupported resource path", thrown.getMessage());
     }

--- a/src/test/java/ch/sbb/polarion/extension/diff_tool/DiffToolAppUIServletTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/diff_tool/DiffToolAppUIServletTest.java
@@ -1,16 +1,69 @@
 package ch.sbb.polarion.extension.diff_tool;
 
-import ch.sbb.polarion.extension.generic.GenericUiServlet;
+import jakarta.servlet.ServletConfig;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+/**
+ * Pins the webapp context this servlet passes to {@code GenericUiServlet}.
+ * <p>
+ * That string is the whole behaviour of the class, and it has to stay identical to the resource
+ * directory {@code src/main/resources/webapp/diff-tool-app/} and to every URL in
+ * {@code META-INF/hivemodule.xml}: the base class serves a request only when its URI starts with
+ * {@code /polarion/<webAppName>/ui/} and strips exactly that prefix to find the resource. A typo
+ * there breaks resource serving at runtime, which is why this asserts the routing rather than the
+ * class hierarchy the compiler already guarantees.
+ */
 class DiffToolAppUIServletTest {
 
-    @Test
-    void instantiatesAsGenericUiServlet() {
-        DiffToolAppUIServlet servlet = new DiffToolAppUIServlet();
+    private DiffToolAppUIServlet servlet;
+    private ServletContext servletContext;
+    private HttpServletResponse response;
 
-        assertThat(servlet).isInstanceOf(GenericUiServlet.class);
+    @BeforeEach
+    void setUp() throws Exception {
+        servletContext = mock(ServletContext.class);
+        ServletConfig servletConfig = mock(ServletConfig.class);
+        when(servletConfig.getServletContext()).thenReturn(servletContext);
+
+        servlet = new DiffToolAppUIServlet();
+        servlet.init(servletConfig);
+        response = mock(HttpServletResponse.class);
+    }
+
+    private HttpServletRequest requestFor(String uri) {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getRequestURI()).thenReturn(uri);
+        return request;
+    }
+
+    @Test
+    void servesFromTheAppWebappContext() throws Exception {
+        when(servletContext.getResourceAsStream(anyString())).thenReturn(null);
+
+        servlet.service(requestFor("/polarion/diff-tool-app/ui/app/index.html"), response);
+
+        // The context prefix is stripped, so what is looked up is the path inside the webapp.
+        verify(servletContext).getResourceAsStream("/app/index.html");
+        verify(response).sendError(HttpServletResponse.SC_NOT_FOUND);
+    }
+
+    @Test
+    void rejectsAnotherWebappContext() {
+        // The extension's other context: a request meant for it must not be served from this app.
+        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
+                () -> servlet.service(requestFor("/polarion/diff-tool/ui/app/index.html"), response));
+
+        assertEquals("Unsupported resource path", thrown.getMessage());
     }
 }


### PR DESCRIPTION
### Proposed changes

Routine maintenance sweep across the extension family. This repository's share:

- build: sort the generated OpenAPI document
- docs: document the UI test flags
- chore: add the missing UI pre-commit hooks
- test: cover the app servlet
- build: bump the generic parent to 15.11.0

The parent bump is the one change here with a runtime effect: the extension ships against generic 15.11.0, which adds the inherited `/disclaimer` endpoint (so `docs/openapi.json`, regenerated by the build, now documents `/api/disclaimer`) and pins `jakarta.annotation` to the API bundle, without which a filter's `@Priority` was ignored and the authentication and authorization filters ordered by `HashSet` iteration order - differently on each JVM start.

Nothing else touches runtime sources: the remaining commits change CI workflows, poms, tests and docs.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation
