### PR TITLE
build: switch to @sbb-polarion/react-sbb-polarion

### DIFF
--- a/ui/README.md
+++ b/ui/README.md
@@ -24,7 +24,7 @@ extra state through `localStorage`. Do not rename them.
 ## Four surfaces
 
 **Admin pages** (`index.html`) are built on the shared
-[`react-sbb-polarion`](https://github.com/grigoriev/react-sbb-polarion) library (RSP), like every other
+[`react-sbb-polarion`](https://github.com/SchweizerischeBundesbahnen/react-sbb-polarion) library (RSP), like every other
 migrated SBB Polarion extension: `PageLayout`, `About`, `ConfigurationButtons`, `RevisionsTable`,
 `Toaster` and the generic control CSS all come from it. The page is chosen by `?feature=<id>`, where the
 ids match the extender ids in `META-INF/hivemodule.xml` - see `src/features.tsx`. Root classes are

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -12,7 +12,7 @@
         "@fortawesome/fontawesome-svg-core": "^7.2.0",
         "@fortawesome/free-solid-svg-icons": "^7.2.0",
         "@fortawesome/react-fontawesome": "^3.3.1",
-        "@grigoriev/react-sbb-polarion": "^0.2.0",
+        "@sbb-polarion/react-sbb-polarion": "^1.0.0",
         "bootstrap": "^5.3.8",
         "chart.js": "^4.5.1",
         "chartjs-adapter-date-fns": "^3.0.0",
@@ -583,24 +583,6 @@
         "react": "^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/@grigoriev/react-sbb-polarion": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@grigoriev/react-sbb-polarion/-/react-sbb-polarion-0.2.0.tgz",
-      "integrity": "sha512-Yiuy22TWG5qWVJLYQx/b0FrMip/FJmfiGp6vUPcXN2JYILTmvuXTPK7vBTWbVOc8cobtnyPRtIx7h+IFn0JzmQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "refractor": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=24.0.0",
-        "npm": ">=11"
-      },
-      "peerDependencies": {
-        "react": "^19.0.0",
-        "react-dom": "^19.0.0",
-        "sonner": "^2.0.7"
-      }
-    },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
@@ -1039,6 +1021,24 @@
       "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@sbb-polarion/react-sbb-polarion": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@sbb-polarion/react-sbb-polarion/-/react-sbb-polarion-1.0.0.tgz",
+      "integrity": "sha512-hTk4oewJvkUL02blEktAJXMc4IiyftaG6fH4+viNP5wdH12mJxKMfHZAmB4xA50vnvFrfdZDhLrxPP/+fC6VwA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "refractor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=24.0.0",
+        "npm": ">=11"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
+        "sonner": "^2.0.7"
+      }
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -4,7 +4,7 @@
     "@fortawesome/fontawesome-svg-core": "^7.2.0",
     "@fortawesome/free-solid-svg-icons": "^7.2.0",
     "@fortawesome/react-fontawesome": "^3.3.1",
-    "@grigoriev/react-sbb-polarion": "^0.2.0",
+    "@sbb-polarion/react-sbb-polarion": "^1.0.0",
     "bootstrap": "^5.3.8",
     "chart.js": "^4.5.1",
     "chartjs-adapter-date-fns": "^3.0.0",

--- a/ui/src/admin/dev/Landing.tsx
+++ b/ui/src/admin/dev/Landing.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { PageLayout, SearchableSelect, getCookie, getScope, setCookie } from '@grigoriev/react-sbb-polarion';
+import { PageLayout, SearchableSelect, getCookie, getScope, setCookie } from '@sbb-polarion/react-sbb-polarion';
 import { FEATURES } from '../../features';
 import { sendRequest } from '../../services/useRemote';
 import type { ProjectInfo } from '../types';

--- a/ui/src/admin/duplication/DuplicationForm.tsx
+++ b/ui/src/admin/duplication/DuplicationForm.tsx
@@ -1,4 +1,4 @@
-import { SearchableSelect } from '@grigoriev/react-sbb-polarion';
+import { SearchableSelect } from '@sbb-polarion/react-sbb-polarion';
 import type { DuplicationRequest, ProjectInfo } from '../types';
 
 interface DuplicationFormProps {

--- a/ui/src/admin/pages/AboutPage.tsx
+++ b/ui/src/admin/pages/AboutPage.tsx
@@ -1,4 +1,4 @@
-import { About } from '@grigoriev/react-sbb-polarion';
+import { About } from '@sbb-polarion/react-sbb-polarion';
 import appIcon from '../../assets/app-icon.svg';
 import useRemote from '../../services/useRemote';
 

--- a/ui/src/admin/pages/DiffConfigurationsPage.tsx
+++ b/ui/src/admin/pages/DiffConfigurationsPage.tsx
@@ -11,7 +11,7 @@ import {
   getProjectIdFromScope,
   getScope,
   useConfirm,
-} from '@grigoriev/react-sbb-polarion';
+} from '@sbb-polarion/react-sbb-polarion';
 import { toast } from 'sonner';
 import useRemote from '../../services/useRemote';
 import useSettings from '../../services/useSettings';

--- a/ui/src/admin/pages/ExecutionQueuePage.tsx
+++ b/ui/src/admin/pages/ExecutionQueuePage.tsx
@@ -6,7 +6,7 @@ import {
   RevisionsTable,
   getScope,
   useConfirm,
-} from '@grigoriev/react-sbb-polarion';
+} from '@sbb-polarion/react-sbb-polarion';
 import { toast } from 'sonner';
 import useRemote from '../../services/useRemote';
 import useSettings, { DEFAULT_CONFIGURATION } from '../../services/useSettings';

--- a/ui/src/admin/pages/MergeAuthorizationPage.tsx
+++ b/ui/src/admin/pages/MergeAuthorizationPage.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
-import { AuthorizationSettings, createAuthorizationService } from '@grigoriev/react-sbb-polarion';
-import type { AuthorizationService } from '@grigoriev/react-sbb-polarion';
+import { AuthorizationSettings, createAuthorizationService } from '@sbb-polarion/react-sbb-polarion';
+import type { AuthorizationService } from '@sbb-polarion/react-sbb-polarion';
 import { sendRequest } from '../../services/useRemote';
 
 /** The `authorization` named setting, whose single "Default" configuration this page edits. */

--- a/ui/src/admin/pages/ProjectDuplicationPage.tsx
+++ b/ui/src/admin/pages/ProjectDuplicationPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { PageLayout } from '@grigoriev/react-sbb-polarion';
+import { PageLayout } from '@sbb-polarion/react-sbb-polarion';
 import { toast } from 'sonner';
 import useRemote from '../../services/useRemote';
 import DuplicationForm, { missingFields } from '../duplication/DuplicationForm';

--- a/ui/src/admin/queue/WorkersConfigurationTable.tsx
+++ b/ui/src/admin/queue/WorkersConfigurationTable.tsx
@@ -1,4 +1,4 @@
-import { SearchableSelect } from '@grigoriev/react-sbb-polarion';
+import { SearchableSelect } from '@sbb-polarion/react-sbb-polarion';
 import type { FeatureInfo } from '../types';
 
 /** Worker 0 means "not queued at all" and is shown as a dash rather than a number. */

--- a/ui/src/entries/topics.tsx
+++ b/ui/src/entries/topics.tsx
@@ -1,6 +1,6 @@
 import { createRoot } from 'react-dom/client';
-import { Toaster, configureGenericModules } from '@grigoriev/react-sbb-polarion';
-import '@grigoriev/react-sbb-polarion/style.css';
+import { Toaster, configureGenericModules } from '@sbb-polarion/react-sbb-polarion';
+import '@sbb-polarion/react-sbb-polarion/style.css';
 import TopicsApp from '../topics/TopicsApp';
 import { GENERIC_MODULES_BASE } from '../topics/genericModules';
 import '../topics/topics.css';

--- a/ui/src/formext/CopyToolPanel.tsx
+++ b/ui/src/formext/CopyToolPanel.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { SearchableSelect } from '@grigoriev/react-sbb-polarion';
+import { SearchableSelect } from '@sbb-polarion/react-sbb-polarion';
 import { sendRequest } from '../services/useRemote';
 import PanelShell from './PanelShell';
 import type { PanelProps } from './panelProps';

--- a/ui/src/formext/DiffToolPanel.tsx
+++ b/ui/src/formext/DiffToolPanel.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { SearchableSelect } from '@grigoriev/react-sbb-polarion';
+import { SearchableSelect } from '@sbb-polarion/react-sbb-polarion';
 import NumericSpinner from './NumericSpinner';
 import PanelShell from './PanelShell';
 import compareIcon from './compare.svg';

--- a/ui/src/formext/rememberedSelection.ts
+++ b/ui/src/formext/rememberedSelection.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect } from 'react';
-import { getCookie, setCookie } from '@grigoriev/react-sbb-polarion';
+import { getCookie, setCookie } from '@sbb-polarion/react-sbb-polarion';
 
 /**
  * Per-dropdown "remember my last choice" for the Document Properties panels.

--- a/ui/src/formext/shadowMount.ts
+++ b/ui/src/formext/shadowMount.ts
@@ -1,4 +1,4 @@
-import styleText from '@grigoriev/react-sbb-polarion/style.css?inline';
+import styleText from '@sbb-polarion/react-sbb-polarion/style.css?inline';
 
 interface ShadowMountOptions {
   /** Classes for the inner container React mounts into (token scope + the wrapper classes the panel's

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -1,6 +1,6 @@
 import { createRoot } from 'react-dom/client';
-import { Toaster, configureGenericModules } from '@grigoriev/react-sbb-polarion';
-import '@grigoriev/react-sbb-polarion/style.css';
+import { Toaster, configureGenericModules } from '@sbb-polarion/react-sbb-polarion';
+import '@sbb-polarion/react-sbb-polarion/style.css';
 import App from './App';
 import './App.css';
 

--- a/ui/src/services/useSettings.ts
+++ b/ui/src/services/useSettings.ts
@@ -1,4 +1,4 @@
-import type { Revision, SettingName } from '@grigoriev/react-sbb-polarion';
+import type { Revision, SettingName } from '@sbb-polarion/react-sbb-polarion';
 // The module-level request function, not the useRemote() wrapper: the service is built once per feature
 // outside of any render, so calling something named use* here would (rightly) trip rules-of-hooks.
 import { sendRequest } from './useRemote';

--- a/ui/src/topics/CollectionsPickerPage.tsx
+++ b/ui/src/topics/CollectionsPickerPage.tsx
@@ -1,5 +1,5 @@
 import { type ReactNode, useEffect, useState } from 'react';
-import type { SettingName } from '@grigoriev/react-sbb-polarion';
+import type { SettingName } from '@sbb-polarion/react-sbb-polarion';
 import { format } from 'date-fns';
 import useRemoteList, { firstError } from '../formext/useRemoteList';
 import ItemsTable, { type Column } from './ItemsTable';

--- a/ui/src/topics/PickerControls.tsx
+++ b/ui/src/topics/PickerControls.tsx
@@ -1,5 +1,5 @@
-import { SearchableSelect } from '@grigoriev/react-sbb-polarion';
-import type { SettingName } from '@grigoriev/react-sbb-polarion';
+import { SearchableSelect } from '@sbb-polarion/react-sbb-polarion';
+import type { SettingName } from '@sbb-polarion/react-sbb-polarion';
 // The same icon the Document Properties panel's Compare button uses.
 import compareIcon from '../formext/compare.svg';
 import type { LinkRoleOption, ProjectInfo } from './types';

--- a/ui/src/topics/WorkItemsPickerPage.tsx
+++ b/ui/src/topics/WorkItemsPickerPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import type { SettingName } from '@grigoriev/react-sbb-polarion';
+import type { SettingName } from '@sbb-polarion/react-sbb-polarion';
 import useRemoteList, { firstError } from '../formext/useRemoteList';
 import ItemsTable, { type Column, EnumCell } from './ItemsTable';
 import Paginator from './Paginator';

--- a/ui/test/DiffConfigurationsPage.test.tsx
+++ b/ui/test/DiffConfigurationsPage.test.tsx
@@ -1,4 +1,4 @@
-import { Toaster } from '@grigoriev/react-sbb-polarion';
+import { Toaster } from '@sbb-polarion/react-sbb-polarion';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, render } from 'vitest-browser-react';
 import DiffConfigurationsPage from '../src/admin/pages/DiffConfigurationsPage';

--- a/ui/test/ExecutionQueuePage.test.tsx
+++ b/ui/test/ExecutionQueuePage.test.tsx
@@ -1,4 +1,4 @@
-import { Toaster } from '@grigoriev/react-sbb-polarion';
+import { Toaster } from '@sbb-polarion/react-sbb-polarion';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, render } from 'vitest-browser-react';
 import ExecutionQueuePage from '../src/admin/pages/ExecutionQueuePage';

--- a/ui/test/MergeAuthorizationPage.test.tsx
+++ b/ui/test/MergeAuthorizationPage.test.tsx
@@ -1,4 +1,4 @@
-import { Toaster } from '@grigoriev/react-sbb-polarion';
+import { Toaster } from '@sbb-polarion/react-sbb-polarion';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, render } from 'vitest-browser-react';
 import MergeAuthorizationPage from '../src/admin/pages/MergeAuthorizationPage';

--- a/ui/test/ProjectDuplicationPage.test.tsx
+++ b/ui/test/ProjectDuplicationPage.test.tsx
@@ -1,4 +1,4 @@
-import { Toaster } from '@grigoriev/react-sbb-polarion';
+import { Toaster } from '@sbb-polarion/react-sbb-polarion';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, render } from 'vitest-browser-react';
 import { formatDuration, formatTime } from '../src/admin/duplication/JobsTable';

--- a/ui/test/setup.ts
+++ b/ui/test/setup.ts
@@ -14,7 +14,7 @@
 //
 // Loading the viewer's globals.css and RSP's stylesheet into one document is only safe because the
 // viewer's page shell is `.diff-app`, not `.app`: RSP claims `.app` for the admin shell.
-import '@grigoriev/react-sbb-polarion/style.css';
+import '@sbb-polarion/react-sbb-polarion/style.css';
 import '@testing-library/jest-dom/vitest';
 import 'bootstrap/dist/css/bootstrap.css';
 import '../src/App.css';

--- a/ui/vitest.config.ts
+++ b/ui/vitest.config.ts
@@ -41,7 +41,7 @@ export default defineConfig({
       'react/jsx-runtime',
       'react/jsx-dev-runtime',
       'vitest-browser-react',
-      '@grigoriev/react-sbb-polarion',
+      '@sbb-polarion/react-sbb-polarion',
       'sonner',
       'chart.js',
       'chartjs-adapter-date-fns',


### PR DESCRIPTION
The shared React library moved from a personal npm scope to the SBB organization and released 1.0.0:
`@grigoriev/react-sbb-polarion` is now
[`@sbb-polarion/react-sbb-polarion`](https://www.npmjs.com/package/@sbb-polarion/react-sbb-polarion).

Only the package name changes. 1.0.0 is 0.2.1 with a different name - the major is there because the
rename itself is the breaking change, not because the API moved. So this is the dependency, its version
range and every import, nothing else.

The stale `github.com/grigoriev/react-sbb-polarion` links follow the repository to
`SchweizerischeBundesbahnen`. `io.github.grigoriev` in `pom.xml` and `grigoriev/pre-commit-*` in
`.pre-commit-config.yaml` are unrelated projects and are left alone.
