### PR TITLE
chore: drop the dead generic stylesheet stub and notes

### DIFF
--- a/ui/e2e/test-utils.js
+++ b/ui/e2e/test-utils.js
@@ -107,16 +107,6 @@ const contentMergeFixtureDataProvider = (requestBody) => {
 
 // API mocking
 export const test = base.extend({
-  // The E2E dev server (`npm run dev`) has no Polarion backend, so the runtime-served
-  // /polarion/.../generic/css/control-tokens.css 404s and its --sbb-* tokens are undefined. That
-  // collapses the token-sized custom checkbox to 0×0, which Playwright treats as not-visible and
-  // refuses to click. Fulfil that request with the checkbox size token (its production value) so
-  // controls stay clickable — kept in the test layer so production globals.css stays token-only.
-  page: async ({ page }, use) => {
-    await page.route("**/generic/css/control-tokens.css", route =>
-      route.fulfill({ contentType: "text/css", body: ":root{--sbb-toggle-size:15px}" }));
-    await use(page);
-  },
   mockApi: async ({ page }, use) => {
     const mockApi = {
       // Mock any API endpoint with certain JSON response in general

--- a/ui/test/setup.ts
+++ b/ui/test/setup.ts
@@ -4,10 +4,10 @@
 // and visual references match runtime:
 //   1. Bootstrap, which the viewer's markup is built on.
 //   2. this app's own globals.css (design-token bridging, layout, the restyled Bootstrap controls).
-// The Polarion-served stylesheets linked from the HTML entries (presentation.css and generic's
-// control-tokens.css / searchable-dropdown.css) are NOT bundled and are deliberately not loaded here -
-// they are baseline chrome resolved at runtime by GenericUiServlet. globals.css carries literal
-// fallbacks for the --sbb-* tokens, which is exactly what the browser sees when those links fail.
+// The one Polarion-served stylesheet the HTML entries still link, presentation.css, is NOT bundled and
+// is deliberately not loaded here - it is baseline chrome resolved at runtime. The --sbb-* tokens no
+// longer depend on such a link: react-sbb-polarion's bundled style.css carries them, and item 3 below
+// loads it, so the browser sees the same token values here as at runtime.
 //
 //   3. react-sbb-polarion's bundled control CSS (tokens + buttons/inputs/checkboxes/alerts + its own
 //      component styles), the same import main.tsx uses, plus this app's App.css for the admin pages.


### PR DESCRIPTION
Follow-up to #622, which removed the last links to generic's stylesheets from the viewer pages.
Two leftovers still describe the world before that change.

- `ui/e2e/test-utils.js` routed `**/generic/css/control-tokens.css` and answered it with
  `--sbb-toggle-size`, because a 404 there collapsed the custom checkbox to 0x0 and Playwright
  refused to click it. Nothing requests that URL any more: the token now comes from
  react-sbb-polarion's bundled `style.css`, which every viewer entry imports. The fixture is
  removed, and the full E2E suite passes without it (252 tests, chromium + firefox + webkit, in
  the pinned CI image).
- `ui/test/setup.ts` told the reader that the `--sbb-*` tokens fall back to literals when the
  Polarion-served links fail. That state is unreachable now. The note names the one stylesheet
  the entries still link, `presentation.css`, and points at the bundle for the tokens.

Comment and test-fixture only. No production code changes.